### PR TITLE
Update MitsubishiHeavyHeatpumpIR.cpp

### DIFF
--- a/MitsubishiHeavyHeatpumpIR.cpp
+++ b/MitsubishiHeavyHeatpumpIR.cpp
@@ -13,7 +13,7 @@ MitsubishiHeavyHeatpumpIR::MitsubishiHeavyHeatpumpIR()
 
 void MitsubishiHeavyHeatpumpIR::send(IRSender& IR, uint8_t powerModeCmd, uint8_t operatingModeCmd, uint8_t fanSpeedCmd, uint8_t temperatureCmd, uint8_t swingVCmd, uint8_t swingHCmd)
 {
-  send(IR, powerModeCmd, operatingModeCmd, fanSpeedCmd, temperatureCmd, swingVCmd, swingHCmd, false);
+  send(IR, powerModeCmd, operatingModeCmd, fanSpeedCmd, temperatureCmd, swingVCmd, swingHCmd, true);
 }
 
 


### PR DESCRIPTION
Cleaning default On. This option will dry the indoor unit after Cooling, Dry-mode and Auto-mode.