### PR TITLE
Adding support for Mitsubishi Heavy Industries SRKXXZMP-S

### DIFF
--- a/MitsubishiHeavyHeatpumpIR.h
+++ b/MitsubishiHeavyHeatpumpIR.h
@@ -21,6 +21,8 @@
 #define MITSUBISHI_HEAVY_MODE_COOL         0x06
 #define MITSUBISHI_HEAVY_MODE_DRY          0x05
 #define MITSUBISHI_HEAVY_MODE_FAN          0x04
+#define MITSUBISHI_HEAVY_ZMP_MODE_FAN      0xD4 //ZMP model seems to have a different value for operating mode 'fan'
+#define MITSUBISHI_HEAVY_ZMP_MODE_MAINT    0x06 //We use the maintenance mode to activate cleaning.
 
 #define MITSUBISHI_HEAVY_MODE_OFF          0x08 // Power OFF
 #define MITSUBISHI_HEAVY_MODE_ON           0x00 // Power ON
@@ -29,7 +31,7 @@
 #define MITSUBISHI_HEAVY_ZJ_FAN1           0xA0
 #define MITSUBISHI_HEAVY_ZJ_FAN2           0x80
 #define MITSUBISHI_HEAVY_ZJ_FAN3           0x60
-#define MITSUBISHI_HEAVY_ZJ_HIPOWER        0x40
+#define MITSUBISHI_HEAVY_ZJ_HIPOWER        0x40 
 #define MITSUBISHI_HEAVY_ZJ_ECONO          0x00
 
 #define MITSUBISHI_HEAVY_ZM_FAN_AUTO       0x0F // Fan speed
@@ -40,9 +42,18 @@
 #define MITSUBISHI_HEAVY_ZM_HIPOWER        0x07
 #define MITSUBISHI_HEAVY_ZM_ECONO          0x09
 
+#define MITSUBISHI_HEAVY_ZMP_FAN_AUTO       0xE0 // Fan speed
+#define MITSUBISHI_HEAVY_ZMP_FAN1           0xA0
+#define MITSUBISHI_HEAVY_ZMP_FAN2           0x80
+#define MITSUBISHI_HEAVY_ZMP_FAN3           0x60
+#define MITSUBISHI_HEAVY_ZMP_HIPOWER        0x20 
+#define MITSUBISHI_HEAVY_ZMP_ECONO          0x00
+
 #define MITSUBISHI_HEAVY_CLEAN_ON          0x00
+#define MITSUBISHI_HEAVY_ZMP_CLEAN_ON      0xDF
 #define MITSUBISHI_HEAVY_ZJ_CLEAN_OFF      0x20
 #define MITSUBISHI_HEAVY_ZM_CLEAN_OFF      0x60
+#define MITSUBISHI_HEAVY_ZMP_CLEAN_OFF     0x20
 
 #define MITSUBISHI_HEAVY_ZM_3DAUTO_ON      0x00 // Only available in Auto, Cool and Heat mode
 #define MITSUBISHI_HEAVY_ZM_3DAUTO_OFF     0x12
@@ -50,6 +61,7 @@
 #define MITSUBISHI_HEAVY_ZJ_SILENT_ON      0x00
 #define MITSUBISHI_HEAVY_ZM_SILENT_ON      0x00 // NOT available in Fan or Dry mode
 #define MITSUBISHI_HEAVY_ZM_SILENT_OFF     0x80
+#define MITSUBISHI_HEAVY_ZMP_SILENT_ON     0x00
 
 #define MITSUBISHI_HEAVY_ZJ_VS_SWING       0x0A // Vertical swing
 #define MITSUBISHI_HEAVY_ZJ_VS_UP          0x02
@@ -66,6 +78,14 @@
 #define MITSUBISHI_HEAVY_ZM_VS_MDOWN       0x60
 #define MITSUBISHI_HEAVY_ZM_VS_DOWN        0x40
 #define MITSUBISHI_HEAVY_ZM_VS_STOP        0x20
+
+#define MITSUBISHI_HEAVY_ZMP_VS_SWING       0x0A // Vertical swing
+#define MITSUBISHI_HEAVY_ZMP_VS_UP          0x02
+#define MITSUBISHI_HEAVY_ZMP_VS_MUP         0x18
+#define MITSUBISHI_HEAVY_ZMP_VS_MIDDLE      0x10
+#define MITSUBISHI_HEAVY_ZMP_VS_MDOWN       0x08
+#define MITSUBISHI_HEAVY_ZMP_VS_DOWN        0x00
+#define MITSUBISHI_HEAVY_ZMP_VS_STOP        0x1A
 
 #define MITSUBISHI_HEAVY_ZJ_HS_SWING       0x4C // Horizontal swing - 3D AUTO
 #define MITSUBISHI_HEAVY_ZJ_HS_MIDDLE      0x48
@@ -88,9 +108,13 @@
 #define MITSUBISHI_HEAVY_ZM_HS_LEFTRIGHT   0x08
 #define MITSUBISHI_HEAVY_ZM_HS_RIGHTLEFT   0x09
 
+//ZMP model does not support horizontal swing
+#define MITSUBISHI_HEAVY_ZMP_HS_STOP       0xCC
+
 // MitsubishiHeavy model codes
 #define MITSUBISHIHEAVY_ZJ 0
 #define MITSUBISHIHEAVY_ZM 1
+#define MITSUBISHIHEAVY_ZMP 2
 
 
 class MitsubishiHeavyHeatpumpIR : public HeatpumpIR
@@ -124,5 +148,14 @@ class MitsubishiHeavyZMHeatpumpIR : public MitsubishiHeavyHeatpumpIR
     void sendMitsubishiHeavy(IRSender& IR, uint8_t powerMode, uint8_t operatingMode, uint8_t fanSpeed, uint8_t temperature, uint8_t swingV, uint8_t swingH, uint8_t cleanMode, uint8_t silentMode, uint8_t _3DAuto);
 };
 
+class MitsubishiHeavyZMPHeatpumpIR : public MitsubishiHeavyHeatpumpIR
+{
+  public:
+    MitsubishiHeavyZMPHeatpumpIR();
+    void send(IRSender& IR, uint8_t powerModeCmd, uint8_t operatingModeCmd, uint8_t fanSpeedCmd, uint8_t temperatureCmd, uint8_t swingVCmd, uint8_t swingHCmd, bool cleanModeCmd, bool silentModeCmd, bool _3DAutoCmd);
+
+  private:
+    void sendMitsubishiHeavy(IRSender& IR, uint8_t powerMode, uint8_t operatingMode, uint8_t fanSpeed, uint8_t temperature, uint8_t swingV, uint8_t swingH, uint8_t cleanMode);
+};
 
 #endif

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ An Arduino library to control pump/split unit air conditioner. Currently support
    * Also Onnline (sold through Onninen) has been reported to work
 * Mitsubishi Heavy SRKxxZJ-S (Remote control P/N RKX502A001C)
 * Mitsubishi Heavy SRKxxZM-S (Remote Control P/N RLA502A700B)
+* Mitsubishi Heavy SRKxxZMP-S (Remote Control P/N RKX502A001P)
 * Mitsubishi MSZ FD-25, probably also FD-35 (remote control P/N KM09D 0052376)
    * Also FH series has been confirmed to work
 * Panasonic E9/E12-CKP (Panasonic remote control P/N A75C2295)


### PR DESCRIPTION
I am adding the support for Mitsubishi Heavy Industries SRKXXZMP-S models (SRK25ZMP-S, SRK35ZMP-S, SRK45ZMP-S). Remote control part number is RKX502A001P. Thanks for your excellent library!