### PR TITLE
Typo into def flag

### DIFF
--- a/MitsubishiSEZKDXXHeatpumpIR.h
+++ b/MitsubishiSEZKDXXHeatpumpIR.h
@@ -3,7 +3,7 @@
 */
 
 #ifndef MitsubishiSEZKDXXHeatpumpIR_h
-#define MitsubishiSEZKDXXaHeatpumpIR_h
+#define MitsubishiSEZKDXXHeatpumpIR_h
 
 #include <HeatpumpIR.h>
 


### PR DESCRIPTION
Removed the char 'a' in: "#define MitsubishiSEZKDXXaHeatpumpIR_h"
to:  "#define MitsubishiSEZKDXXHeatpumpIR_h" 
Causing duplicate declaration in IDE different from the arduino.