### PR TITLE
Support for YAA1FB, FAA1FB1, YB1F2 remotes

### DIFF
--- a/AUXHeatpumpIR.h
+++ b/AUXHeatpumpIR.h
@@ -1,5 +1,5 @@
 /*
-    AUX heatpump control (remote control YKR-N/002E )
+    AUX heatpump control (remote control YKR-N/002E, YKR-P/002E)
 */
 #ifndef AUXHeatpumpIR_h
 #define AUXHeatpumpIR_h

--- a/GreeHeatpumpIR.h
+++ b/GreeHeatpumpIR.h
@@ -21,10 +21,10 @@
 // Operating modes
 // Gree codes
 #define GREE_AIRCON1_MODE_AUTO  0x00
-#define GREE_AIRCON1_MODE_HEAT  0x04
 #define GREE_AIRCON1_MODE_COOL  0x01
 #define GREE_AIRCON1_MODE_DRY   0x02
 #define GREE_AIRCON1_MODE_FAN   0x03
+#define GREE_AIRCON1_MODE_HEAT  0x04
 
 // Fan speeds. Note that some heatpumps have less than 5 fan speeds
 #define GREE_AIRCON1_FAN_AUTO   0x00 // Fan speed
@@ -58,6 +58,7 @@
 // Gree model codes
 #define GREE_GENERIC 0
 #define GREE_YAN     1
+#define GREE_YAA     2
 
 
 class GreeHeatpumpIR : public HeatpumpIR
@@ -84,6 +85,15 @@ class GreeYANHeatpumpIR : public GreeHeatpumpIR
 {
   public:
     GreeYANHeatpumpIR();
+
+  public:
+    void send(IRSender& IR, uint8_t powerModeCmd, uint8_t operatingModeCmd, uint8_t fanSpeedCmd, uint8_t temperatureCmd, uint8_t swingVCmd, uint8_t swingHCmd, bool turboMode);
+};
+
+class GreeYAAHeatpumpIR : public GreeHeatpumpIR
+{
+  public:
+    GreeYAAHeatpumpIR();
 
   public:
     void send(IRSender& IR, uint8_t powerModeCmd, uint8_t operatingModeCmd, uint8_t fanSpeedCmd, uint8_t temperatureCmd, uint8_t swingVCmd, uint8_t swingHCmd, bool turboMode);

--- a/README.md
+++ b/README.md
@@ -12,8 +12,9 @@ An Arduino library to control pump/split unit air conditioner. Currently support
 * Carrier 42NQV035G / 38NYV035H2 (Carrier remote control P/N WH-L05SE)
 * Daikin RXS25G2V1B / FVXS25FV1B (Remote control P/N ARC452A1)
 * Hisense AUD (remote control Y-H1-01,  Y-H1-02(E), Y-J1, Y-E4-07) probably AUC model
-* Hyundai (Remote Control P/N Y512F2)
+* Hyundai (remote control P/N Y512F2)
    * This is probably a generic Gree model
+   * Model H-AR21-07H (remote control P/N YKR-P/002E) confirmed as AUX
 * Fujitsu Nocria AWYZ14 (remote control P/N AR-PZ2)
    * Also Fujitsu remote controls RY3-AR and AR-RCE1E
 * IVT AY-XP12FR-N (remote control CRMC-A673JBEZ)
@@ -35,6 +36,8 @@ An Arduino library to control pump/split unit air conditioner. Currently support
 * Toshiba Daiseikai (Toshiba remote control P/N WH-TA01EE).
    * Fully compatible with CarrierNQV functions instead of Daiseikai functions.
    * Tested with: RAS-10G2KVP-E RAS-10G2AVP-E and RAS-13G2KVP-E RAS-13G2AVP-E
+* Tosot T18H-SN/I (remote control P/N YAA1FB) as GreeYAA variant
+   * Also marketed as Tadiran brand
 
 
 

--- a/examples/simple/simple.ino
+++ b/examples/simple/simple.ino
@@ -41,7 +41,7 @@ HeatpumpIR *heatpumpIR[] = {new PanasonicCKPHeatpumpIR(), new PanasonicDKEHeatpu
                             new MitsubishiHeavyZJHeatpumpIR(), new MitsubishiHeavyZMHeatpumpIR(),
                             new MitsubishiSEZKDXXHeatpumpIR(),
                             new HyundaiHeatpumpIR(), new HisenseHeatpumpIR(),
-                            new GreeGenericHeatpumpIR(), new GreeYANHeatpumpIR(),
+                            new GreeGenericHeatpumpIR(), new GreeYANHeatpumpIR(), new GreeYAAHeatpumpIR(),
                             new FuegoHeatpumpIR(), new ToshibaHeatpumpIR(), new ToshibaDaiseikaiHeatpumpIR(),
                             new IVTHeatpumpIR(), new HitachiHeatpumpIR(),
                             new BalluHeatpumpIR(), new AUXHeatpumpIR(),

--- a/keywords.txt
+++ b/keywords.txt
@@ -31,6 +31,7 @@ HisenseHeatpumpIR	KEYWORD1
 GreeHeatpumpIR	KEYWORD1
 GreeGenericHeatpumpIR	KEYWORD1
 GreeYANHeatpumpIR	KEYWORD1
+GreeYAAHeatpumpIR	KEYWORD1
 FuegoHeatpumpIR	KEYWORD1
 ToshibaHeatpumpIR	KEYWORD1
 IVTHeatpumpIR	KEYWORD1


### PR DESCRIPTION
Added support for these remotes based on the document published on that thread: [https://forum.mysensors.org/topic/4253/ac-ir-code-decrypting](url)

Tested to work with Tosot T18H-SN/I (remote control P/N YAA1FB).

Also added Hyundai Model H-AR21-07H (remote control P/N YKR-P/002E) confirmed as AUX (tested to work).