### PR TITLE
ESP32 support added

### DIFF
--- a/IRSender.h
+++ b/IRSender.h
@@ -59,6 +59,21 @@ class IRSenderBitBang : public IRSender
     int _halfPeriodicTime;
 };
 
+#ifdef ESP32
+class IRSenderESP32 : public IRSender
+{
+  public:
+    IRSenderESP32(uint8_t pin, uint8_t pwmChannel);
+    void setFrequency(int frequency);
+    void space(int spaceLength);
+    void mark(int markLength);
+
+  protected:
+    uint32_t _frequency;
+    uint8_t _pwmChannel;
+};
+#endif
+
 #ifdef ESP8266
 class IRSenderIRremoteESP8266 : public IRSender
 {

--- a/IRSenderESP32.cpp
+++ b/IRSenderESP32.cpp
@@ -1,0 +1,44 @@
+#include <Arduino.h>
+
+// IRSender implementation for ESP32
+// Tested on R51M/E control with SENSEI air conditioner 
+// Maksym Krasovskyi
+
+#if defined ESP32
+#include <IRSender.h>
+IRSenderESP32::IRSenderESP32(uint8_t pin, uint8_t pwmChannel) : IRSender(pin)
+{
+  _pwmChannel = pwmChannel;
+  pinMode(_pin, OUTPUT);
+}
+
+void IRSenderESP32::setFrequency(int frequency)
+{
+  _frequency = frequency;
+}
+
+// Send an IR 'mark' symbol, i.e. transmitter ON
+void IRSenderESP32::mark(int markLength)
+{
+  ledcSetup(_pwmChannel, _frequency, 8);
+  ledcAttachPin(_pin, _pwmChannel);
+  long beginning = micros();
+  ledcWrite(_pwmChannel, 127);
+  while((int)(micros() - beginning) < markLength);
+  gpio_reset_pin(static_cast<gpio_num_t>(_pin));
+  digitalWrite(_pin, LOW);
+}
+
+// Send an IR 'space' symbol, i.e. transmitter OFF
+void IRSenderESP32::space(int spaceLength)
+{
+  digitalWrite(_pin, LOW);
+
+  if (spaceLength < 16383) {
+    delayMicroseconds(spaceLength);
+  } else {
+    delay(spaceLength/1000);
+  }
+}
+
+#endif

--- a/IRSenderPWM.cpp
+++ b/IRSenderPWM.cpp
@@ -2,7 +2,8 @@
 #include <IRSender.h>
 
 // ESP8266 does not have the Arduino PWM control registers
-#ifndef ESP8266 
+
+#if not defined ESP8266 && not defined ESP32
 
 // Heavily based on Ken Shirriff's IRRemote library:
 // https://github.com/shirriff/Arduino-IRremote


### PR DESCRIPTION
ESP32 support addedwith native PWM
Tested on R51M/E remote control

Example:
`heatpumpIR = new R51MHeatpumpIR();
IRSenderESP32 irSender(2, 0);  
heatpumpIR->send(irSender, POWER_ON, MODE_COOL, FAN_2, 22, VDIR_UP, HDIR_AUTO);
`
