### PR TITLE
Enable Arduino Mega pins 44,45,46 + checksum calc fixes

### DIFF
--- a/IRSenderPWM.cpp
+++ b/IRSenderPWM.cpp
@@ -114,10 +114,12 @@ void IRSenderPWM::setFrequency(int frequency)
       // Fall-through to 46, timer 5 controls pins 44, 45 and 46 on Arduino Mega
     case 45:
     case 46:
-      TCCR5A = _BV(WGM51) | _BV(WGM50);
+      TCCR5A = _BV(WGM51); // This gives correct data from pins 44,45,46 and similar range to pin 9
       TCCR5B = _BV(WGM53) | _BV(CS50);
       ICR5 = pwmval16;
       OCR5A = pwmval16 / 3;
+      OCR5B = pwmval16 / 3; // Also enable pin 45
+      OCR5C = pwmval16 / 3; // Also enable pin 44
 #else
 // Arduino Duemilanove etc
 #if !defined(__AVR_ATmega8__)

--- a/ToshibaDaiseikaiHeatpumpIR.cpp
+++ b/ToshibaDaiseikaiHeatpumpIR.cpp
@@ -97,45 +97,7 @@ void ToshibaDaiseikaiHeatpumpIR::sendDaiseikai(IRSender& IR, uint8_t operatingMo
   // Checksum
 
   for (int i=0; i<8; i++) {
-    checksum += IR.bitReverse(sendBuffer[i]);
-  }
-
-  // There's something really strange with the checksum calculation...
-  // With these many of the codes matchs with the code from the real Carrier remote
-  // Still certain temperatures do not work with fan speeds 1, 2 or 5
-
-  switch (sendBuffer[6] & 0xF0) {
-  case 0x00: // MODE_AUTO - certain temperature / fan speed combinations do not work
-    checksum += 0x02;
-    switch (sendBuffer[6] & 0x0F) {
-      case 0x02: // FAN1
-      case 0x03: // FAN5
-      case 0x06: // FAN2
-        checksum += 0x80;
-        break;
-    }
-    break;
-  case 0x40: // MODE_DRY - all settings should work
-    checksum += 0x02;
-    break;
-  case 0xC0: // MODE_HEAT - certain temperature / fan speed combinations do not work
-    switch (sendBuffer[6] & 0x0F) {
-      case 0x05: // FAN4
-      case 0x06: // FAN2
-        checksum += 0xC0;
-        break;
-    }
-    break;
-  case 0x20: // MODE_FAN - all settings should work
-    checksum += 0x02;
-    switch (sendBuffer[6] & 0x0F) {
-      case 0x02: // FAN1
-      case 0x03: // FAN5
-      case 0x06: // FAN2
-        checksum += 0x80;
-        break;
-    }
-    break;
+    checksum ^= IR.bitReverse(sendBuffer[i]);
   }
 
   sendBuffer[8] = IR.bitReverse(checksum);

--- a/ToshibaDaiseikaiHeatpumpIR.h
+++ b/ToshibaDaiseikaiHeatpumpIR.h
@@ -12,10 +12,13 @@
 // https://github.com/ToniA/arduino-heatpumpir/issues/23
 #define DAISEIKAI_AIRCON1_HDR_MARK   4320
 #define DAISEIKAI_AIRCON1_HDR_SPACE  4350
-#define DAISEIKAI_AIRCON1_BIT_MARK   500
+//#define DAISEIKAI_AIRCON1_BIT_MARK   500 // Adjusted for compatibility - remote WH-H05JE
+#define DAISEIKAI_AIRCON1_BIT_MARK   550 // Adjusted for compatibility - remote WH-H05JE
 #define DAISEIKAI_AIRCON1_ONE_SPACE  1650
-#define DAISEIKAI_AIRCON1_ZERO_SPACE 550
-#define DAISEIKAI_AIRCON1_MSG_SPACE  7400
+//#define DAISEIKAI_AIRCON1_ZERO_SPACE 550 // Adjusted for compatibility - remote WH-H05JE
+#define DAISEIKAI_AIRCON1_ZERO_SPACE 485 // Adjusted for compatibility - remote WH-H05JE
+//#define DAISEIKAI_AIRCON1_MSG_SPACE  7400 // Adjusted so that MSG_SPACE would be always inserted
+#define DAISEIKAI_AIRCON1_MSG_SPACE  7900 // Adjusted so that MSG_SPACE would be always inserted
 
 // Toshiba Daiseikai (Carrier) codes. Same as CarrierNQV ?
 #define DAISEIKAI_AIRCON1_MODE_AUTO  0x00 // Operating mode


### PR DESCRIPTION
- Fixed Arduino MEGA pins 44 and 45 not working
- Fixed Arduino MEGA pins 44, 45, 46 not working correctly (low range, inconsistent payload)
- Fixed Toshiba Daiseikai checksum calculation
- Adjusted Toshiba Daiseikai timings, pause space was for some reason mostly omitted, atleast on my Arduino MEGA, after the changes, pause space is never omitted, the proposed timings are verified with remote WH-H05JE on both: Raw-IR-decoder-for-Arduino and IRrecvDumpV2 from the IRremoteESP8266 project.