### PR TITLE
Added version and dependencies to library.json

### DIFF
--- a/library.json
+++ b/library.json
@@ -12,5 +12,14 @@
     "url": "https://github.com/ToniA/arduino-heatpumpir.git"
   },
   "frameworks": "arduino",
-  "platforms": "atmelavr"
+  "platforms": ["atmelavr", "espressif32", "espressif8266"],
+  "version": "1.0.15",
+  "dependencies": [
+    {
+      "owner": "crankyoldgit",
+      "name": "IRremoteESP8266",
+      "version": "~2.7.12",
+      "platforms": ["espressif8266"]
+    }
+  ]
 }


### PR DESCRIPTION
This PR means that:

- [https://platformio.org/lib/show/290/HeatpumpIR](https://platformio.org/lib/show/290/HeatpumpIR) will show the correct version.
- PlatformIO will automatically download the required library for ESP8266.

I am requesting this to make it easier to provide arduino-heatpumpir to users of esphome (see https://github.com/esphome/esphome/pull/1343)

Could you please also run `pio package publish` after merging these changes?