### PR TITLE
Add support for GreeYAC and I-Feel

### DIFF
--- a/GreeHeatpumpIR.h
+++ b/GreeHeatpumpIR.h
@@ -44,21 +44,22 @@
 #define GREE_VDIR_MDOWN  0x05
 #define GREE_VDIR_DOWN   0x06
 
-// Not available in this model.
+// Only available on YAC
 // Horizontal air directions. Note that these cannot be set on all heat pumps
-#define GREE_HDIR_AUTO   0
-#define GREE_HDIR_MANUAL 0
-#define GREE_HDIR_SWING  0
-#define GREE_HDIR_MIDDLE 0
-#define GREE_HDIR_LEFT   0
-#define GREE_HDIR_MLEFT  0
-#define GREE_HDIR_MRIGHT 0
-#define GREE_HDIR_RIGHT  0
+#define GREE_HDIR_AUTO   0x00
+#define GREE_HDIR_MANUAL 0x00
+#define GREE_HDIR_SWING  0x01
+#define GREE_HDIR_LEFT   0x02
+#define GREE_HDIR_MLEFT  0x03
+#define GREE_HDIR_MIDDLE 0x04
+#define GREE_HDIR_MRIGHT 0x05
+#define GREE_HDIR_RIGHT  0x06
 
 // Gree model codes
 #define GREE_GENERIC 0
 #define GREE_YAN     1
 #define GREE_YAA     2
+#define GREE_YAC     3
 
 
 class GreeHeatpumpIR : public HeatpumpIR
@@ -70,9 +71,10 @@ class GreeHeatpumpIR : public HeatpumpIR
   public:
     void send(IRSender& IR, uint8_t powerModeCmd, uint8_t operatingModeCmd, uint8_t fanSpeedCmd, uint8_t temperatureCmd, uint8_t swingVCmd, uint8_t swingHCmd);
     void send(IRSender& IR, uint8_t powerModeCmd, uint8_t operatingModeCmd , uint8_t fanSpeedCmd , uint8_t temperatureCmd , uint8_t swingVCmd , uint8_t swingHCmd, bool turboMode);
+    void send(IRSender& IR, uint8_t powerModeCmd, uint8_t operatingModeCmd , uint8_t fanSpeedCmd , uint8_t temperatureCmd , uint8_t swingVCmd , uint8_t swingHCmd, bool turboMode, bool iFeelMode);
 
   private:
-    void sendGree(IRSender& IR, uint8_t powerMode, uint8_t operatingMode, uint8_t fanSpeed, uint8_t temperature, uint8_t swingV, uint8_t swingH, bool turboMode);
+    void sendGree(IRSender& IR, uint8_t powerMode, uint8_t operatingMode, uint8_t fanSpeed, uint8_t temperature, uint8_t swingV, uint8_t swingH, bool turboMode, bool iFeelMode);
 };
 
 class GreeGenericHeatpumpIR : public GreeHeatpumpIR
@@ -87,7 +89,10 @@ class GreeYANHeatpumpIR : public GreeHeatpumpIR
     GreeYANHeatpumpIR();
 
   public:
-    void send(IRSender& IR, uint8_t powerModeCmd, uint8_t operatingModeCmd, uint8_t fanSpeedCmd, uint8_t temperatureCmd, uint8_t swingVCmd, uint8_t swingHCmd, bool turboMode);
+    void send(IRSender& IR, uint8_t powerModeCmd, uint8_t operatingModeCmd, uint8_t fanSpeedCmd, uint8_t temperatureCmd, uint8_t swingVCmd, uint8_t swingHCmd, bool turboMode)
+    {
+      GreeHeatpumpIR::send(IR, powerModeCmd, operatingModeCmd, fanSpeedCmd, temperatureCmd, swingVCmd, swingHCmd, turboMode);
+    }
 };
 
 class GreeYAAHeatpumpIR : public GreeHeatpumpIR
@@ -96,7 +101,23 @@ class GreeYAAHeatpumpIR : public GreeHeatpumpIR
     GreeYAAHeatpumpIR();
 
   public:
-    void send(IRSender& IR, uint8_t powerModeCmd, uint8_t operatingModeCmd, uint8_t fanSpeedCmd, uint8_t temperatureCmd, uint8_t swingVCmd, uint8_t swingHCmd, bool turboMode);
+    void send(IRSender& IR, uint8_t powerModeCmd, uint8_t operatingModeCmd, uint8_t fanSpeedCmd, uint8_t temperatureCmd, uint8_t swingVCmd, uint8_t swingHCmd, bool turboMode)
+    {
+      GreeHeatpumpIR::send(IR, powerModeCmd, operatingModeCmd, fanSpeedCmd, temperatureCmd, swingVCmd, swingHCmd, turboMode);
+    }
+};
+
+class GreeYACHeatpumpIR : public GreeHeatpumpIR
+{
+  public:
+    GreeYACHeatpumpIR();
+
+  public:
+    void send(IRSender& IR, uint8_t powerModeCmd, uint8_t operatingModeCmd, uint8_t fanSpeedCmd, uint8_t temperatureCmd, uint8_t swingVCmd, uint8_t swingHCmd, bool turboMode, bool iFeelMode)
+    {
+      GreeHeatpumpIR::send(IR, powerModeCmd, operatingModeCmd, fanSpeedCmd, temperatureCmd, swingVCmd, swingHCmd, turboMode, iFeelMode);
+    }
+    void send(IRSender& IR, uint8_t currentTemperature);
 };
 
 #endif

--- a/examples/GreeTest/GreeYACTest/GreeYACTest.ino
+++ b/examples/GreeTest/GreeYACTest/GreeYACTest.ino
@@ -1,0 +1,62 @@
+#include <Arduino.h>
+#include <GreeHeatpumpIR.h>
+
+IRSenderPWM irSender(9);     // IR led on Duemilanove digital pin 3, using Arduino PWM
+//IRSenderBlaster irSender(3); // IR led on Duemilanove digital pin 3, using IR Blaster (generates the 38 kHz carrier)
+
+GreeYACHeatpumpIR *heatpumpIR;
+
+int redLED = 6;
+int orangeLED = 5;
+int greenLED = 4;
+int blueLED = 3;
+
+void setup()
+{
+  Serial.begin(9600);
+  pinMode(redLED, OUTPUT);
+  pinMode(orangeLED, OUTPUT);
+  pinMode(greenLED, OUTPUT);
+  pinMode(blueLED, OUTPUT);
+  delay(500);
+  heatpumpIR = new GreeYACHeatpumpIR();
+  Serial.println(F("Starting"));
+}
+
+void loop()
+{
+  const char* buf;
+
+  Serial.print(F("Sending IR to "));
+  // Print the model
+  buf = heatpumpIR->model();
+  // 'model' is a PROGMEM pointer, so need to write a byte at a time
+  while (char modelChar = pgm_read_byte(buf++))
+  {
+    Serial.print(modelChar);
+  }
+  Serial.print(F(", info: "));
+  // Print the info
+  buf = heatpumpIR->info();
+  // 'info' is a PROGMEM pointer, so need to write a byte at a time
+  while (char infoChar = pgm_read_byte(buf++))
+  {
+    Serial.print(infoChar);
+  }
+  Serial.println();
+
+  digitalWrite(orangeLED,HIGH);
+  delay(4000);
+  heatpumpIR->send(irSender, POWER_ON, MODE_HEAT, FAN_AUTO, 24, VDIR_AUTO, HDIR_AUTO, false, true);
+
+  delay(4000);
+  heatpumpIR->send(irSender, 24);
+  
+  digitalWrite(orangeLED,LOW);
+
+  digitalWrite(redLED, HIGH);
+
+  // don't loop()
+  for(;;)
+    ;
+}


### PR DESCRIPTION
A few changes coming in around Gree heatpumps.

1. Classes for GreeYAN, GreeYAA didn't actually implement their send() functions properly, that is fixed.
2. Added GreeYAC class and send with support for Horizontal Swing, I-Feel, and current temperature
3. Added example for testing GreeYAC class

I've tested this on a breadboard for the moment, with and IR receiver and it does appear to work. It'll need more testing which I'll carry out in the coming weeks, but I think this is good to merge right now.

CLOSES: #86 