### PR TITLE
Adjust timings for Gree I-Feel messages

### DIFF
--- a/GreeHeatpumpIR.cpp
+++ b/GreeHeatpumpIR.cpp
@@ -329,14 +329,14 @@ void GreeYACHeatpumpIR::send(IRSender& IR, uint8_t currentTemperature)
   IR.setFrequency(38);
 
   // Send Header mark
-  IR.mark(GREE_AIRCON1_HDR_MARK);
-  IR.space(GREE_AIRCON1_HDR_SPACE);
+  IR.mark(GREE_YAC_HDR_MARK);
+  IR.space(GREE_YAC_HDR_SPACE);
 
   // send payload
-  IR.sendIRbyte(GreeTemplate[0], GREE_AIRCON1_BIT_MARK, GREE_AIRCON1_ZERO_SPACE, GREE_AIRCON1_ONE_SPACE);
-  IR.sendIRbyte(GreeTemplate[1], GREE_AIRCON1_BIT_MARK, GREE_AIRCON1_ZERO_SPACE, GREE_AIRCON1_ONE_SPACE);
+  IR.sendIRbyte(GreeTemplate[0], GREE_YAC_BIT_MARK, GREE_AIRCON1_ZERO_SPACE, GREE_AIRCON1_ONE_SPACE);
+  IR.sendIRbyte(GreeTemplate[1], GREE_YAC_BIT_MARK, GREE_AIRCON1_ZERO_SPACE, GREE_AIRCON1_ONE_SPACE);
 
   // End mark
-  IR.mark(GREE_AIRCON1_BIT_MARK);
+  IR.mark(GREE_YAC_BIT_MARK);
   IR.space(0);
 }

--- a/GreeHeatpumpIR.h
+++ b/GreeHeatpumpIR.h
@@ -14,6 +14,11 @@
 #define GREE_AIRCON1_ZERO_SPACE 540
 #define GREE_AIRCON1_MSG_SPACE  19000
 
+// Timing specific for YAC features (I-Feel mode)
+#define GREE_YAC_HDR_MARK   6000
+#define GREE_YAC_HDR_SPACE  3000
+#define GREE_YAC_BIT_MARK   650
+
 // Power state
 #define GREE_AIRCON1_POWER_OFF  0x00
 #define GREE_AIRCON1_POWER_ON   0x08

--- a/HeatpumpIR.cpp
+++ b/HeatpumpIR.cpp
@@ -13,6 +13,11 @@ void HeatpumpIR::send(IRSender&, uint8_t, uint8_t, uint8_t, uint8_t, uint8_t, ui
 {
 }
 
+// Send ambient temperature. This is a virtual function, i.e. never called
+void HeatpumpIR::send(IRSender&, uint8_t)
+{
+}
+
 // Heatpump model and info getters
 const char PROGMEM* HeatpumpIR::model()
 {

--- a/HeatpumpIR.h
+++ b/HeatpumpIR.h
@@ -63,6 +63,7 @@ class HeatpumpIR
 
   public:
     virtual void send(IRSender& IR, uint8_t powerModeCmd, uint8_t operatingModeCmd, uint8_t fanSpeedCmd, uint8_t temperatureCmd, uint8_t swingVCmd, uint8_t swingHCmd);
+    virtual void send(IRSender& IR, uint8_t currentTemperature);
     const char PROGMEM* model();
     const char PROGMEM* info();
     virtual ~HeatpumpIR();


### PR DESCRIPTION
Addresses an issues raised in #117.

The I-Feel message feature for Gree YAC devices uses a separate set of timings for the feature message.

I've been running this for the last year+ on my Gree device without issues, took me a little while and some other data in the Issue to confirm my suspicion that it was just the message (and not my device).