### PR TITLE
fixed typo in GreeHeatpumpIR::sendGree for YAN variant

### DIFF
--- a/GreeHeatpumpIR.cpp
+++ b/GreeHeatpumpIR.cpp
@@ -224,14 +224,8 @@ void GreeHeatpumpIR::sendGree(IRSender& IR, uint8_t powerMode, uint8_t operating
   // Gree YAN-specific
   if (greeModel == GREE_YAN)
   {
-    GreeTemplate[2] = 0x60;
+    GreeTemplate[2] = turboMode ? 0x70 : 0x60;
     GreeTemplate[3] = 0x50;
-
-    if (turboMode)
-    {
-      GreeTemplate[2]=0x70;
-    }
-
     GreeTemplate[4] = swingV;
   }
   if (greeModel == GREE_YAC)

--- a/GreeHeatpumpIR.cpp
+++ b/GreeHeatpumpIR.cpp
@@ -225,7 +225,7 @@ void GreeHeatpumpIR::sendGree(IRSender& IR, uint8_t powerMode, uint8_t operating
   if (greeModel == GREE_YAN)
   {
     GreeTemplate[2] = 0x60;
-    GreeTemplate[2] = 0x50;
+    GreeTemplate[3] = 0x50;
 
     if (turboMode)
     {


### PR DESCRIPTION
looks just like a typo, see the code =)
rechecked that with dumping the real RC - yes, 3rd byte is always 0x50, 2nd is 0x60/0x70 depending on turbo mode.

please bump/tag version for yourself, thank you.