### PR TITLE
Hardcoded Temperature-Range ist too small

### DIFF
--- a/SamsungHeatpumpIR.cpp
+++ b/SamsungHeatpumpIR.cpp
@@ -292,7 +292,7 @@ void SamsungFJMHeatpumpIR::send(IRSender& IR, uint8_t powerModeCmd, uint8_t oper
       break;
   }
 
-  if ( temperatureCmd > 15 && temperatureCmd < 28)
+  if ( temperatureCmd > 15 && temperatureCmd < 31)
   {
     temperature = temperatureCmd;
   }


### PR DESCRIPTION
The temperature range in this code is set to 16-27°C.
16°C as low level is correct, Lower temp is not possible in the communication-protocol.
On my Samsung MH035FPEA-unit the maximum temperature is 30°C. For heating mode it would be nice to set this from the arduino-control.

Matthias