### PR TITLE
Add inverted LED support to IRSenderESP32

### DIFF
--- a/IRSender.cpp
+++ b/IRSender.cpp
@@ -44,6 +44,14 @@ uint8_t IRSender::bitReverse(uint8_t x)
 }
 
 
+// Some boards have inverted signals, so we need to set the pin to HIGH to turn the IR transmitter off
+// For example M5Stick-C where LED positive on VCC and negative on pin 9
+void IRSender::invert(bool inverted)
+{
+  _inverted = inverted;
+}
+
+
 // Definitions of virtual functions
 void IRSender::setFrequency(int) {};
 void IRSender::space(int) {};

--- a/IRSender.h
+++ b/IRSender.h
@@ -29,11 +29,13 @@ class IRSender
     virtual void setFrequency(int frequency);
     void sendIRbyte(uint8_t sendByte, int bitMarkLength, int zeroSpaceLength, int oneSpaceLength);
     uint8_t bitReverse(uint8_t x);
+    virtual void invert(bool inverted);
     virtual void space(int spaceLength);
     virtual void mark(int markLength);
 
   protected:
     uint8_t _pin;
+    bool _inverted = false;
 };
 
 

--- a/IRSenderESP32.cpp
+++ b/IRSenderESP32.cpp
@@ -10,6 +10,10 @@ IRSenderESP32::IRSenderESP32(uint8_t pin, uint8_t pwmChannel) : IRSender(pin)
 {
   _pwmChannel = pwmChannel;
   pinMode(_pin, OUTPUT);
+  // If we have an inverted signal, we need to set the pin from default LOW
+  // to HIGH to make it off
+  if (_inverted)
+    digitalWrite(_pin, HIGH);
 }
 
 void IRSenderESP32::setFrequency(int frequency)
@@ -26,13 +30,19 @@ void IRSenderESP32::mark(int markLength)
   ledcWrite(_pwmChannel, 127);
   while((int)(micros() - beginning) < markLength);
   gpio_reset_pin(static_cast<gpio_num_t>(_pin));
-  digitalWrite(_pin, LOW);
+  if (_inverted)
+    digitalWrite(_pin, HIGH);
+  else
+    digitalWrite(_pin, LOW);
 }
 
 // Send an IR 'space' symbol, i.e. transmitter OFF
 void IRSenderESP32::space(int spaceLength)
 {
-  digitalWrite(_pin, LOW);
+  if (_inverted)
+    digitalWrite(_pin, HIGH);
+  else
+    digitalWrite(_pin, LOW);
 
   if (spaceLength < 16383) {
     delayMicroseconds(spaceLength);


### PR DESCRIPTION
Some development boards like M5Stick-C have inverted LED, so when pin HIGH - led is off , etc.
To support that we need minor changes in code, unfortunately i dont have other boards, but inverted LED can be added to other senders easily.
Tested on Gree A/C and M5Stick-C.