### PR TITLE
[ESP32] Fix compatibility with ESP32 Arduino 3.0 and ESP-IDF 5.1.x

### DIFF
--- a/IRSenderESP32.cpp
+++ b/IRSenderESP32.cpp
@@ -6,6 +6,9 @@
 
 #if defined ESP32
 #include <IRSender.h>
+#if ( defined(ESP_ARDUINO_VERSION_MAJOR) && (ESP_ARDUINO_VERSION_MAJOR >= 3) )
+#include <driver/gpio.h>
+#endif  // ESP_ARDUINO_VERSION_MAJOR >= 3
 IRSenderESP32::IRSenderESP32(uint8_t pin, uint8_t pwmChannel) : IRSender(pin)
 {
   _pwmChannel = pwmChannel;
@@ -20,10 +23,18 @@ void IRSenderESP32::setFrequency(int frequency)
 // Send an IR 'mark' symbol, i.e. transmitter ON
 void IRSenderESP32::mark(int markLength)
 {
+#if ( defined(ESP_ARDUINO_VERSION_MAJOR) && (ESP_ARDUINO_VERSION_MAJOR >= 3) )
+  ledcAttach(_pin, _frequency, 8);
+#else   // ESP_ARDUINO_VERSION_MAJOR >= 3
   ledcSetup(_pwmChannel, _frequency, 8);
   ledcAttachPin(_pin, _pwmChannel);
+#endif  // ESP_ARDUINO_VERSION_MAJOR >= 3
   long beginning = micros();
+#if ( defined(ESP_ARDUINO_VERSION_MAJOR) && (ESP_ARDUINO_VERSION_MAJOR >= 3) )
+  ledcWrite(_pin, 127);
+#else   // ESP_ARDUINO_VERSION_MAJOR >= 3
   ledcWrite(_pwmChannel, 127);
+#endif  // ESP_ARDUINO_VERSION_MAJOR >= 3
   while((int)(micros() - beginning) < markLength);
   gpio_reset_pin(static_cast<gpio_num_t>(_pin));
   digitalWrite(_pin, LOW);


### PR DESCRIPTION
This fixes compatibility with ESP32 Arduino 3.0, that includes Espressif IDF 5.1.x.
Features:
- Include low-level `gpio*` functions from IDF, no longer included by default
- Adjust code for changed IDF `ledc*` functions and signatures
- Backward compatible with current ESP32 Arduino 2.0.x (with ESP-IDF 4.x)


Edit: For full compatibility with Arduino 3.0, IRremoteESP8266 still needs some changes, as similar patches have been PR'ed there (based on Tasmota code-changes), but that's at this time not yet fully working...