### PR TITLE
Update HeatpumpIRFactory to support greeyac and greeyt

### DIFF
--- a/HeatpumpIRFactory.cpp
+++ b/HeatpumpIRFactory.cpp
@@ -29,6 +29,10 @@ HeatpumpIR* HeatpumpIRFactory::create(const char *modelName) {
     return new GreeYAAHeatpumpIR();
   } else if (strcmp_P(modelName, PSTR("greeyan")) == 0) {
     return new GreeYANHeatpumpIR();
+  } else if (strcmp_P(modelName, PSTR("greeyac")) == 0) {
+    return new GreeYACHeatpumpIR();
+  } else if (strcmp_P(modelName, PSTR("greeyt")) == 0) {
+    return new GreeYTHeatpumpIR();
   } else if (strcmp_P(modelName, PSTR("hisense_aud")) == 0) {
     return new HisenseHeatpumpIR();
   } else if (strcmp_P(modelName, PSTR("hitachi")) == 0) {


### PR DESCRIPTION
This change allows creating `greeyac` and `greeyt` controllers using `HeatpumpIRFactory::create`.