### PR TITLE
Remove unnecessary constraints

### DIFF
--- a/library.json
+++ b/library.json
@@ -18,8 +18,7 @@
     {
       "owner": "crankyoldgit",
       "name": "IRremoteESP8266",
-      "version": "~2.8.4",
-      "platforms": ["espressif8266"]
+      "version": "~2.8.4"
     }
   ]
 }


### PR DESCRIPTION
The `IRremoteESP8266` library is compatible with ESP32/ESP8266