### PR TITLE
Enable iFeel by default, fix fan control to be compatible with ESPHOME

### DIFF
--- a/NibeHeatpumpIR.cpp
+++ b/NibeHeatpumpIR.cpp
@@ -71,7 +71,7 @@ NibeHeatpumpIR::NibeHeatpumpIR() : HeatpumpIR()
 
 void NibeHeatpumpIR::send(IRSender& IR, uint8_t powerModeCmd, uint8_t operatingModeCmd, uint8_t fanSpeedCmd, uint8_t temperatureCmd, uint8_t swingVCmd, uint8_t swingHCmd)
 {
-  send(IR, powerModeCmd, operatingModeCmd, fanSpeedCmd, temperatureCmd, swingVCmd, swingHCmd, false, false);
+  send(IR, powerModeCmd, operatingModeCmd, fanSpeedCmd, temperatureCmd, swingVCmd, swingHCmd, false, true);
 }
 
 void NibeHeatpumpIR::send(IRSender& IR, uint8_t powerModeCmd, uint8_t operatingModeCmd, uint8_t fanSpeedCmd, uint8_t temperatureCmd, uint8_t swingVCmd, uint8_t swingHCmd, bool turboModeCmd, bool iFeelModeCmd)
@@ -120,24 +120,23 @@ void NibeHeatpumpIR::send(IRSender& IR, uint8_t powerModeCmd, uint8_t operatingM
     }
   }
 
-  // NOTE Fan speed Auto can not be used in MODE_FAN
-  // TODO not sure this fan mapping is correct? FAN_1 = low speed and FAN_3 = high speed?
+  // NOTE Fan speed Auto can not be used in NIBE_MODE_FAN
   switch (fanSpeedCmd)
   {
     case FAN_AUTO:
       if (operatingMode == NIBE_MODE_FAN)
-        fanSpeed = NIBE_MODE_FAN1;
+        fanSpeed = NIBE_MODE_FAN_HIGH;
       else
         fanSpeed = NIBE_MODE_FAN_AUTO;
       break;
-    case FAN_1:
-      fanSpeed = NIBE_MODE_FAN3;
+    case FAN_4:				// FAN_4 = CLIMATE_FAN_HIGH - ESPHOME
+      fanSpeed = NIBE_MODE_FAN_HIGH;
       break;
-    case FAN_2:
-      fanSpeed = NIBE_MODE_FAN2;
+    case FAN_3:				// FAN_3 = CLIMATE_FAN_MEDIUM - ESPHOME
+      fanSpeed = NIBE_MODE_FAN_MED;
       break;
-    case FAN_3:
-      fanSpeed = NIBE_MODE_FAN1;
+    case FAN_2:				// FAN_2 = CLIMATE_FAN_LOW - ESPHOME
+      fanSpeed = NIBE_MODE_FAN_LOW;
       break;
     case FAN_SILENT:
       nightMode = 0x01;

--- a/NibeHeatpumpIR.h
+++ b/NibeHeatpumpIR.h
@@ -32,11 +32,11 @@
 #define NIBE_MODE_AUTO_COOL      0x02
 
 // Fan speeds (2 bits)
-//NOTE Fan speed Auto can not be used in MODE_FAN
-#define NIBE_MODE_FAN_AUTO   0x00 // Fan speed
-#define NIBE_MODE_FAN1       0x03 // * Max
-#define NIBE_MODE_FAN2       0x01 // * Medium
-#define NIBE_MODE_FAN3       0x02 // * Low
+//NOTE Fan speed Auto can not be used in NIBE_MODE_FAN
+#define NIBE_MODE_FAN_AUTO  0x00
+#define NIBE_MODE_FAN_HIGH  0x03
+#define NIBE_MODE_FAN_MED   0x01
+#define NIBE_MODE_FAN_LOW   0x02
 
 // Vertical air directions (3 bits)
 // Note according to the remote control manual there are limitations:


### PR DESCRIPTION
Hey @ToniA,

a small update to the Nibe Heatpump code that I submitted earlier this year.
- I enable iFeel by default. For the case that no IFeel sensor is available the unit will use its internal build in sensor
- Adjusted the fan definitions to work correctly with ESP home

Are there any plans to release a new version of platformio? Would like to get this code into ESPHOME IR Remote Climate.

Greetings Fabian