### PR TITLE
Add support for Gree YAP protocol 

### DIFF
--- a/GreeHeatpumpIR.cpp
+++ b/GreeHeatpumpIR.cpp
@@ -309,36 +309,38 @@ void GreeHeatpumpIR::sendGree(IRSender& IR, uint8_t powerMode, uint8_t operating
       0x0A) & 0x0F) << 4) | (GreeTemplate[7] & 0x0F);
   }
 
+  const auto & timings = getTimings();
+
   // 38 kHz PWM frequency
   IR.setFrequency(38);
 
   // Send Header mark
-  IR.mark(GREE_AIRCON1_HDR_MARK);
-  IR.space(GREE_AIRCON1_HDR_SPACE);
+  IR.mark(timings.hdr_mark);
+  IR.space(timings.hdr_space);
 
   // Payload part #1
   for (i=0; i<4; i++) {
-    IR.sendIRbyte(GreeTemplate[i], GREE_AIRCON1_BIT_MARK, GREE_AIRCON1_ZERO_SPACE, GREE_AIRCON1_ONE_SPACE);
+    IR.sendIRbyte(GreeTemplate[i], timings.bit_mark, timings.zero_space, timings.one_space);
   }
   // Only three first bits of byte 4 are sent, this is always '010'
-  IR.mark(GREE_AIRCON1_BIT_MARK);
-  IR.space(GREE_AIRCON1_ZERO_SPACE);
-  IR.mark(GREE_AIRCON1_BIT_MARK);
-  IR.space(GREE_AIRCON1_ONE_SPACE);
-  IR.mark(GREE_AIRCON1_BIT_MARK);
-  IR.space(GREE_AIRCON1_ZERO_SPACE);
+  IR.mark(timings.bit_mark);
+  IR.space(timings.zero_space);
+  IR.mark(timings.bit_mark);
+  IR.space(timings.one_space);
+  IR.mark(timings.bit_mark);
+  IR.space(timings.zero_space);
 
   // Message space
-  IR.mark(GREE_AIRCON1_BIT_MARK);
-  IR.space(GREE_AIRCON1_MSG_SPACE);
+  IR.mark(timings.bit_mark);
+  IR.space(timings.msg_space);
 
   // Payload part #2
   for (i=4; i<8; i++) {
-    IR.sendIRbyte(GreeTemplate[i], GREE_AIRCON1_BIT_MARK, GREE_AIRCON1_ZERO_SPACE, GREE_AIRCON1_ONE_SPACE);
-	}
+    IR.sendIRbyte(GreeTemplate[i], timings.bit_mark, timings.zero_space, timings.one_space);
+  }
 
   // End mark
-  IR.mark(GREE_AIRCON1_BIT_MARK);
+  IR.mark(timings.bit_mark);
   IR.space(0);
 }
 
@@ -350,18 +352,20 @@ void GreeiFeelHeatpumpIR::send(IRSender& IR, uint8_t currentTemperature)
   GreeTemplate[0] = currentTemperature;
   GreeTemplate[1] = 0xA5;
 
+  const auto & timings = getTimings();
+
   // 38 kHz PWM frequency
   IR.setFrequency(38);
 
   // Send Header mark
-  IR.mark(GREE_YAC_HDR_MARK);
-  IR.space(GREE_YAC_HDR_SPACE);
+  IR.mark(timings.ifeel_hdr_mark);
+  IR.space(timings.ifeel_hdr_space);
 
   // send payload
-  IR.sendIRbyte(GreeTemplate[0], GREE_YAC_BIT_MARK, GREE_AIRCON1_ZERO_SPACE, GREE_AIRCON1_ONE_SPACE);
-  IR.sendIRbyte(GreeTemplate[1], GREE_YAC_BIT_MARK, GREE_AIRCON1_ZERO_SPACE, GREE_AIRCON1_ONE_SPACE);
+  IR.sendIRbyte(GreeTemplate[0], timings.ifeel_bit_mark, timings.zero_space, timings.one_space);
+  IR.sendIRbyte(GreeTemplate[1], timings.ifeel_bit_mark, timings.zero_space, timings.one_space);
 
   // End mark
-  IR.mark(GREE_YAC_BIT_MARK);
+  IR.mark(timings.ifeel_bit_mark);
   IR.space(0);
 }

--- a/GreeHeatpumpIR.cpp
+++ b/GreeHeatpumpIR.cpp
@@ -1,69 +1,20 @@
 #include "GreeHeatpumpIR.h"
 
-// This is a protected method, i.e. generic Gree instances cannot be created
-GreeHeatpumpIR::GreeHeatpumpIR() : HeatpumpIR()
-{
-}
+namespace {
 
-GreeGenericHeatpumpIR::GreeGenericHeatpumpIR() : GreeHeatpumpIR()
-{
-  static const char model[] PROGMEM = "gree";
-  static const char info[]  PROGMEM = "{\"mdl\":\"gree\",\"dn\":\"Gree\",\"mT\":16,\"xT\":30,\"fs\":3}";
-
-  _model = model;
-  _info = info;
-}
-
-GreeYANHeatpumpIR::GreeYANHeatpumpIR() : GreeHeatpumpIR()
-{
-  static const char model[] PROGMEM = "greeyan";
-  static const char info[]  PROGMEM = "{\"mdl\":\"greeyan\",\"dn\":\"Gree YAN\",\"mT\":16,\"xT\":30,\"fs\":3}";
-
-  _model = model;
-  _info = info;
-}
-
-// Support for YAA1FB, FAA1FB1, YB1F2 remotes
-GreeYAAHeatpumpIR::GreeYAAHeatpumpIR() : GreeHeatpumpIR()
-{
-  static const char model[] PROGMEM = "greeyaa";
-  static const char info[]  PROGMEM = "{\"mdl\":\"greeyaa\",\"dn\":\"Gree YAA\",\"mT\":16,\"xT\":30,\"fs\":3}";
-
-  _model = model;
-  _info = info;
-}
-
-// Support for YAC1FBF remote
-GreeYACHeatpumpIR::GreeYACHeatpumpIR() : GreeiFeelHeatpumpIR()
-{
-  static const char model[] PROGMEM = "greeyac";
-  static const char info[]  PROGMEM = "{\"mdl\":\"greeyac\",\"dn\":\"Gree YAC\",\"mT\":16,\"xT\":30,\"fs\":3}";
-
-  _model = model;
-  _info = info;
-}
-
-// Support for YT1F remote
-GreeYTHeatpumpIR::GreeYTHeatpumpIR() : GreeiFeelHeatpumpIR()
-{
-  static const char model[] PROGMEM = "greeyt";
-  static const char info[]  PROGMEM = "{\"mdl\":\"greeyt\",\"dn\":\"Gree YT\",\"mT\":16,\"xT\":30,\"fs\":3}";
-
-  _model = model;
-  _info = info;
-}
-
-void GreeHeatpumpIR::send(IRSender& IR, uint8_t powerModeCmd, uint8_t operatingModeCmd, uint8_t fanSpeedCmd, uint8_t temperatureCmd, uint8_t swingVCmd, uint8_t swingHCmd, bool turboMode, bool iFeelMode)
+void convert_params(
+  uint8_t powerModeCmd, uint8_t operatingModeCmd, uint8_t fanSpeedCmd, uint8_t temperatureCmd,
+  uint8_t swingVCmd, uint8_t swingHCmd, bool turboMode, bool iFeelMode,
+  uint8_t & powerMode, uint8_t & operatingMode, uint8_t & fanSpeed,
+  uint8_t & temperature, uint8_t & swingV, uint8_t & swingH)
 {
   // Sensible defaults for the heat pump mode
-
-  uint8_t powerMode = GREE_AIRCON1_POWER_ON;
-  uint8_t operatingMode = GREE_AIRCON1_MODE_HEAT;
-  uint8_t fanSpeed = GREE_AIRCON1_FAN_AUTO;
-  uint8_t temperature = 21;
-  uint8_t swingV = GREE_VDIR_AUTO;
-  uint8_t swingH = GREE_HDIR_AUTO;
-
+  powerMode = GREE_AIRCON1_POWER_ON;
+  operatingMode = GREE_AIRCON1_MODE_HEAT;
+  fanSpeed = GREE_AIRCON1_FAN_AUTO;
+  temperature = 21;
+  swingV = GREE_VDIR_AUTO;
+  swingH = GREE_HDIR_AUTO;
 
   if (powerModeCmd == POWER_OFF)
   {
@@ -163,8 +114,115 @@ void GreeHeatpumpIR::send(IRSender& IR, uint8_t powerModeCmd, uint8_t operatingM
   {
     temperature = temperatureCmd - 16;
   }
+}
+
+}
+
+// This is a protected method, i.e. generic Gree instances cannot be created
+GreeHeatpumpIR::GreeHeatpumpIR() : HeatpumpIR()
+{
+}
+
+GreeGenericHeatpumpIR::GreeGenericHeatpumpIR() : GreeHeatpumpIR()
+{
+  static const char model[] PROGMEM = "gree";
+  static const char info[]  PROGMEM = "{\"mdl\":\"gree\",\"dn\":\"Gree\",\"mT\":16,\"xT\":30,\"fs\":3}";
+
+  _model = model;
+  _info = info;
+}
+
+GreeYANHeatpumpIR::GreeYANHeatpumpIR() : GreeHeatpumpIR()
+{
+  static const char model[] PROGMEM = "greeyan";
+  static const char info[]  PROGMEM = "{\"mdl\":\"greeyan\",\"dn\":\"Gree YAN\",\"mT\":16,\"xT\":30,\"fs\":3}";
+
+  _model = model;
+  _info = info;
+}
+
+// Support for YAA1FB, FAA1FB1, YB1F2 remotes
+GreeYAAHeatpumpIR::GreeYAAHeatpumpIR() : GreeHeatpumpIR()
+{
+  static const char model[] PROGMEM = "greeyaa";
+  static const char info[]  PROGMEM = "{\"mdl\":\"greeyaa\",\"dn\":\"Gree YAA\",\"mT\":16,\"xT\":30,\"fs\":3}";
+
+  _model = model;
+  _info = info;
+}
+
+// Support for YAC1FBF remote
+GreeYACHeatpumpIR::GreeYACHeatpumpIR() : GreeiFeelHeatpumpIR()
+{
+  static const char model[] PROGMEM = "greeyac";
+  static const char info[]  PROGMEM = "{\"mdl\":\"greeyac\",\"dn\":\"Gree YAC\",\"mT\":16,\"xT\":30,\"fs\":3}";
+
+  _model = model;
+  _info = info;
+}
+
+// Support for YT1F remote
+GreeYTHeatpumpIR::GreeYTHeatpumpIR() : GreeiFeelHeatpumpIR()
+{
+  static const char model[] PROGMEM = "greeyt";
+  static const char info[]  PROGMEM = "{\"mdl\":\"greeyt\",\"dn\":\"Gree YT\",\"mT\":16,\"xT\":30,\"fs\":3}";
+
+  _model = model;
+  _info = info;
+}
+
+// Support for YAP1F remote
+GreeYAPHeatpumpIR::GreeYAPHeatpumpIR() : GreeiFeelHeatpumpIR()
+{
+  static const char model[] PROGMEM = "greeyap";
+  static const char info[]  PROGMEM = "{\"mdl\":\"greeyap\",\"dn\":\"Gree YAP\",\"mT\":16,\"xT\":30,\"fs\":3}";
+
+  _model = model;
+  _info = info;
+}
+
+const GreeHeatpumpIR::Timings & GreeHeatpumpIR::getTimings() const {
+    static Timings timings = {
+        9000,
+        4000,
+        620,
+        1600,
+        540,
+        19000,
+        8200,
+        3800,
+        650,
+    };
+    return timings;
+};
+
+void GreeHeatpumpIR::send(IRSender& IR, uint8_t powerModeCmd, uint8_t operatingModeCmd, uint8_t fanSpeedCmd, uint8_t temperatureCmd, uint8_t swingVCmd, uint8_t swingHCmd, bool turboMode, bool iFeelMode)
+{
+  uint8_t powerMode, operatingMode, fanSpeed, temperature, swingV, swingH;
+
+  convert_params(
+    powerModeCmd, operatingModeCmd, fanSpeedCmd, temperatureCmd,
+    swingVCmd, swingHCmd, turboMode, iFeelMode,
+    powerMode, operatingMode, fanSpeed,
+    temperature, swingV, swingH);
 
   sendGree(IR, powerMode, operatingMode, fanSpeed, temperature, swingV, swingH, turboMode, iFeelMode);
+}
+
+// Send the Gree code
+void GreeHeatpumpIR::sendGree(IRSender& IR, uint8_t powerMode, uint8_t operatingMode, uint8_t fanSpeed, uint8_t temperature, uint8_t swingV, uint8_t swingH, bool turboMode, bool iFeelMode)
+{
+  uint8_t buffer[8];
+
+  generateCommand(
+      buffer,
+      powerMode, operatingMode,
+      fanSpeed, temperature,
+      swingV, swingH,
+      turboMode, iFeelMode);
+
+  calculateChecksum(buffer);
+  sendBuffer(IR, buffer);
 }
 
 void GreeHeatpumpIR::generateCommand(uint8_t * buffer,
@@ -307,6 +365,60 @@ void GreeYTHeatpumpIR::generateCommand(uint8_t * buffer,
   }
 }
 
+void GreeYAPHeatpumpIR::generateCommand(uint8_t * buffer,
+            uint8_t powerMode, uint8_t operatingMode,
+            uint8_t fanSpeed, uint8_t temperature,
+            uint8_t swingV, uint8_t swingH,
+            bool turboMode, bool iFeelMode) {
+  generateCommand(buffer,
+                  powerMode, operatingMode,
+                  fanSpeed, temperature,
+                  swingV, swingH,
+                  turboMode, iFeelMode,
+                  true);
+}
+
+void GreeYAPHeatpumpIR::generateCommand(uint8_t * buffer,
+            uint8_t powerMode, uint8_t operatingMode,
+            uint8_t fanSpeed, uint8_t temperature,
+            uint8_t swingV, uint8_t swingH,
+            bool turboMode, bool iFeelMode,
+            bool light, bool xfan,
+            bool health, bool valve,
+            bool sthtMode, bool enableWiFi) {
+
+  GreeiFeelHeatpumpIR::generateCommand(buffer,
+      powerMode, operatingMode,
+      fanSpeed, temperature,
+      swingV, swingH,
+      turboMode, iFeelMode);
+
+  buffer[2] =
+    (turboMode ? (1 << 4) : 0) |
+    (light ? (1 << 5) : 0) |
+    (health ? (1 << 6) : 0) |
+    (xfan ? (1 << 7) : 0);
+
+  buffer[3] = 0x50 | (valve ? (1 << 0) : 0);  // bits 4..7 always 0101
+
+  buffer[4] = swingV | (swingH << 4);
+
+  buffer[5] = 0x82 |
+    (iFeelMode ? (1 << 2) : 0) |  // note that this is different than in the other devices
+    (enableWiFi ? (1 << 6) : 0);
+
+  buffer[7] = (sthtMode ? (1 << 2) : 0);
+
+  memset(buffer + 8, 0, 16);
+  memcpy(buffer + 8, buffer, 3);
+
+  buffer[8 + 3] = 0x70 |
+    (valve ? (1 << 0) : 0);
+
+  buffer[16 + 3] = 0xA0;
+  buffer[16 + 7] = 0xA0;
+}
+
 void GreeHeatpumpIR::calculateChecksum(uint8_t * buffer) {
   buffer[7] = (((
    (buffer[0] & 0x0F) +
@@ -326,53 +438,134 @@ void GreeYANHeatpumpIR::calculateChecksum(uint8_t * buffer) {
     0xC0);
 }
 
-// Send the Gree code
-void GreeHeatpumpIR::sendGree(IRSender& IR, uint8_t powerMode, uint8_t operatingMode, uint8_t fanSpeed, uint8_t temperature, uint8_t swingV, uint8_t swingH, bool turboMode, bool iFeelMode)
-{
-  uint8_t GreeTemplate[8];
-
-  generateCommand(
-      GreeTemplate,
-      powerMode, operatingMode,
-      fanSpeed, temperature,
-      swingV, swingH,
-      turboMode, iFeelMode);
-
-  calculateChecksum(GreeTemplate);
-
+void GreeHeatpumpIR::sendBuffer(IRSender& IR, const uint8_t * buffer, size_t len) {
   const auto & timings = getTimings();
 
   // 38 kHz PWM frequency
   IR.setFrequency(38);
 
-  // Send Header mark
-  IR.mark(timings.hdr_mark);
-  IR.space(timings.hdr_space);
+  for (size_t pos = 0; pos < len; pos += 8) {
+    // All but the first group must be preceded by a space
+    if (pos) {
+      IR.mark(timings.bit_mark);
+      IR.space(timings.msg_space);
+    }
 
-  // Payload part #1
-  for (int i=0; i<4; i++) {
-    IR.sendIRbyte(GreeTemplate[i], timings.bit_mark, timings.zero_space, timings.one_space);
+    // Send Header mark
+    IR.mark(timings.hdr_mark);
+    IR.space(timings.hdr_space);
+
+    // Payload part #1
+    for (size_t i = 0; i < 4; i++) {
+      IR.sendIRbyte(buffer[pos + i], timings.bit_mark, timings.zero_space, timings.one_space);
+    }
+    // Only three first bits of byte 4 are sent, this is always '010'
+    IR.mark(timings.bit_mark);
+    IR.space(timings.zero_space);
+    IR.mark(timings.bit_mark);
+    IR.space(timings.one_space);
+    IR.mark(timings.bit_mark);
+    IR.space(timings.zero_space);
+
+    // Message space
+    IR.mark(timings.bit_mark);
+    IR.space(timings.msg_space);
+
+    // Payload part #2
+    for (size_t i = 4; i < 8; i++) {
+      IR.sendIRbyte(buffer[pos + i], timings.bit_mark, timings.zero_space, timings.one_space);
+    }
+
+    // End mark
+    IR.mark(timings.bit_mark);
+    IR.space(0);
   }
-  // Only three first bits of byte 4 are sent, this is always '010'
-  IR.mark(timings.bit_mark);
-  IR.space(timings.zero_space);
-  IR.mark(timings.bit_mark);
-  IR.space(timings.one_space);
-  IR.mark(timings.bit_mark);
-  IR.space(timings.zero_space);
+}
 
-  // Message space
-  IR.mark(timings.bit_mark);
-  IR.space(timings.msg_space);
+const GreeHeatpumpIR::Timings & GreeYAPHeatpumpIR::getTimings() const {
+    static Timings timings = {
+        9000,
+        4500,
+        650,
+        1643,
+        510,
+        20000,
+        6000,
+        3000,
+        650,
+    };
+    return timings;
+};
 
-  // Payload part #2
-  for (int i=4; i<8; i++) {
-    IR.sendIRbyte(GreeTemplate[i], timings.bit_mark, timings.zero_space, timings.one_space);
+// Send the Gree code
+void GreeYAPHeatpumpIR::sendGree(
+        IRSender& IR,
+        uint8_t powerMode, uint8_t operatingMode,
+        uint8_t fanSpeed, uint8_t temperature,
+        uint8_t swingV, uint8_t swingH,
+        bool turboMode, bool iFeelMode) {
+  sendGree(IR,
+           powerMode, operatingMode,
+           fanSpeed, temperature,
+           swingV, swingH,
+           turboMode, iFeelMode,
+           true);
+}
+
+void GreeYAPHeatpumpIR::sendGree(
+        IRSender& IR,
+        uint8_t powerMode, uint8_t operatingMode,
+        uint8_t fanSpeed, uint8_t temperature,
+        uint8_t swingV, uint8_t swingH,
+        bool turboMode, bool iFeelMode,
+        bool light, bool xfan,
+        bool health, bool valve,
+        bool sthtMode, bool enableWiFi) {
+
+  uint8_t buffer[24];
+
+  generateCommand(
+      buffer,
+      powerMode, operatingMode,
+      fanSpeed, temperature,
+      swingV, swingH,
+      turboMode, iFeelMode,
+      light, xfan,
+      health, valve,
+      sthtMode, enableWiFi);
+
+  calculateChecksum(buffer);
+  calculateChecksum(buffer + 8);
+
+  sendBuffer(IR, buffer, 24);
+
+  for (size_t offset = 0; offset < 24; ++offset) {
+      Serial.printf("%2i: %02x\n", offset, buffer[offset]);
   }
+}
 
-  // End mark
-  IR.mark(timings.bit_mark);
-  IR.space(0);
+void GreeYAPHeatpumpIR::send(
+          IRSender& IR,
+          uint8_t powerModeCmd, uint8_t operatingModeCmd,
+          uint8_t fanSpeedCmd, uint8_t temperatureCmd,
+          uint8_t swingVCmd, uint8_t swingHCmd,
+          bool turboMode, bool iFeelMode,
+          bool light, bool xfan,
+          bool health, bool valve,
+          bool sthtMode, bool enableWiFi) {
+  uint8_t powerMode, operatingMode, fanSpeed, temperature, swingV, swingH;
+
+  convert_params(
+    powerModeCmd, operatingModeCmd, fanSpeedCmd, temperatureCmd,
+    swingVCmd, swingHCmd, turboMode, iFeelMode,
+    powerMode, operatingMode, fanSpeed,
+    temperature, swingV, swingH);
+
+  sendGree(IR,
+           powerMode, operatingMode, fanSpeed, temperature,
+           swingV, swingH, turboMode, iFeelMode,
+           light, xfan, health,
+           valve, sthtMode, enableWiFi);
 }
 
 // Sends current sensed temperatures, YAC remotes/supporting units only

--- a/GreeHeatpumpIR.cpp
+++ b/GreeHeatpumpIR.cpp
@@ -12,7 +12,6 @@ GreeGenericHeatpumpIR::GreeGenericHeatpumpIR() : GreeHeatpumpIR()
 
   _model = model;
   _info = info;
-  greeModel = GREE_GENERIC;
 }
 
 GreeYANHeatpumpIR::GreeYANHeatpumpIR() : GreeHeatpumpIR()
@@ -22,7 +21,6 @@ GreeYANHeatpumpIR::GreeYANHeatpumpIR() : GreeHeatpumpIR()
 
   _model = model;
   _info = info;
-  greeModel = GREE_YAN;
 }
 
 // Support for YAA1FB, FAA1FB1, YB1F2 remotes
@@ -33,7 +31,6 @@ GreeYAAHeatpumpIR::GreeYAAHeatpumpIR() : GreeHeatpumpIR()
 
   _model = model;
   _info = info;
-  greeModel = GREE_YAA;
 }
 
 // Support for YAC1FBF remote
@@ -44,7 +41,6 @@ GreeYACHeatpumpIR::GreeYACHeatpumpIR() : GreeiFeelHeatpumpIR()
 
   _model = model;
   _info = info;
-  greeModel = GREE_YAC;
 }
 
 // Support for YT1F remote
@@ -55,24 +51,10 @@ GreeYTHeatpumpIR::GreeYTHeatpumpIR() : GreeiFeelHeatpumpIR()
 
   _model = model;
   _info = info;
-  greeModel = GREE_YT;
-}
-
-void GreeHeatpumpIR::send(IRSender& IR, uint8_t powerModeCmd, uint8_t operatingModeCmd, uint8_t fanSpeedCmd, uint8_t temperatureCmd, uint8_t swingVCmd, uint8_t swingHCmd)
-{
-  send(IR, powerModeCmd, operatingModeCmd, fanSpeedCmd, temperatureCmd, swingVCmd, swingHCmd, false);
-}
-
-void GreeHeatpumpIR::send(IRSender& IR, uint8_t powerModeCmd, uint8_t operatingModeCmd, uint8_t fanSpeedCmd, uint8_t temperatureCmd, uint8_t swingVCmd, uint8_t swingHCmd, bool turboMode)
-{
-  send(IR, powerModeCmd, operatingModeCmd, fanSpeedCmd, temperatureCmd, swingVCmd, swingHCmd, turboMode, false);
 }
 
 void GreeHeatpumpIR::send(IRSender& IR, uint8_t powerModeCmd, uint8_t operatingModeCmd, uint8_t fanSpeedCmd, uint8_t temperatureCmd, uint8_t swingVCmd, uint8_t swingHCmd, bool turboMode, bool iFeelMode)
 {
-  (void)swingVCmd;
-  (void)swingHCmd;
-
   // Sensible defaults for the heat pump mode
 
   uint8_t powerMode = GREE_AIRCON1_POWER_ON;
@@ -127,87 +109,55 @@ void GreeHeatpumpIR::send(IRSender& IR, uint8_t powerModeCmd, uint8_t operatingM
       break;
   }
 
-
-  if (greeModel == GREE_YAN)
+  switch (swingVCmd)
   {
-    switch (swingVCmd)
-    {
-      case VDIR_AUTO:
-      case VDIR_SWING:
-        swingV = GREE_VDIR_AUTO;
-        break;
-      case VDIR_UP:
-        swingV = GREE_VDIR_UP;
-        break;
-      case VDIR_MUP:
-        swingV = GREE_VDIR_MUP;
-        break;
-      case VDIR_MIDDLE:
-        swingV = GREE_VDIR_MIDDLE;
-        break;
-      case VDIR_MDOWN:
-        swingV = GREE_VDIR_MDOWN;
-        break;
-      case VDIR_DOWN:
-        swingV = GREE_VDIR_DOWN;
-        break;
-    }
+    case VDIR_AUTO:
+      swingV = GREE_VDIR_AUTO;
+      break;
+    case VDIR_SWING:
+      swingV = GREE_VDIR_SWING;
+      break;
+    case VDIR_UP:
+      swingV = GREE_VDIR_UP;
+      break;
+    case VDIR_MUP:
+      swingV = GREE_VDIR_MUP;
+      break;
+    case VDIR_MIDDLE:
+      swingV = GREE_VDIR_MIDDLE;
+      break;
+    case VDIR_MDOWN:
+      swingV = GREE_VDIR_MDOWN;
+      break;
+    case VDIR_DOWN:
+      swingV = GREE_VDIR_DOWN;
+      break;
   }
 
-  if (greeModel == GREE_YAA || greeModel == GREE_YAC || greeModel == GREE_YT)
+  switch (swingHCmd)
   {
-    switch (swingVCmd)
-    {
-      case VDIR_AUTO:
-        swingV = GREE_VDIR_AUTO;
-        break;
-      case VDIR_SWING:
-        swingV = GREE_VDIR_SWING;
-        break;
-      case VDIR_UP:
-        swingV = GREE_VDIR_UP;
-        break;
-      case VDIR_MUP:
-        swingV = GREE_VDIR_MUP;
-        break;
-      case VDIR_MIDDLE:
-        swingV = GREE_VDIR_MIDDLE;
-        break;
-      case VDIR_MDOWN:
-        swingV = GREE_VDIR_MDOWN;
-        break;
-      case VDIR_DOWN:
-        swingV = GREE_VDIR_DOWN;
-        break;
-    }
-
-    if (greeModel == GREE_YAC)
-    {
-      switch (swingHCmd)
-      {
-        case HDIR_AUTO:
-        case HDIR_SWING:
-          swingH = GREE_HDIR_SWING;
-          break;
-        case HDIR_LEFT:
-          swingH = GREE_HDIR_LEFT;
-          break;
-        case HDIR_MLEFT:
-          swingH = GREE_HDIR_MLEFT;
-          break;
-        case HDIR_MIDDLE:
-          swingH = GREE_HDIR_MIDDLE;
-          break;
-        case HDIR_MRIGHT:
-          swingH = GREE_HDIR_MRIGHT;
-          break;
-        case HDIR_RIGHT:
-          swingH = GREE_HDIR_RIGHT;
-          break;
-      }
-    }
+    case HDIR_AUTO:
+      swingH = GREE_HDIR_AUTO;
+      break;
+    case HDIR_SWING:
+      swingH = GREE_HDIR_SWING;
+      break;
+    case HDIR_LEFT:
+      swingH = GREE_HDIR_LEFT;
+      break;
+    case HDIR_MLEFT:
+      swingH = GREE_HDIR_MLEFT;
+      break;
+    case HDIR_MIDDLE:
+      swingH = GREE_HDIR_MIDDLE;
+      break;
+    case HDIR_MRIGHT:
+      swingH = GREE_HDIR_MRIGHT;
+      break;
+    case HDIR_RIGHT:
+      swingH = GREE_HDIR_RIGHT;
+      break;
   }
-
 
   if (temperatureCmd > 15 && temperatureCmd < 31)
   {
@@ -217,97 +167,178 @@ void GreeHeatpumpIR::send(IRSender& IR, uint8_t powerModeCmd, uint8_t operatingM
   sendGree(IR, powerMode, operatingMode, fanSpeed, temperature, swingV, swingH, turboMode, iFeelMode);
 }
 
+void GreeHeatpumpIR::generateCommand(uint8_t * buffer,
+            uint8_t powerMode, uint8_t operatingMode,
+            uint8_t fanSpeed, uint8_t temperature,
+            uint8_t swingV, uint8_t swingH,
+            bool turboMode, bool iFeelMode) {
+
+  memset(buffer, 0, 8);
+
+  // Set the Fan speed, operating mode and power state
+  buffer[0] = fanSpeed | operatingMode | powerMode;
+
+  // Set the temperature
+  buffer[1] = temperature;
+}
+
+void GreeYANHeatpumpIR::generateCommand(uint8_t * buffer,
+            uint8_t powerMode, uint8_t operatingMode,
+            uint8_t fanSpeed, uint8_t temperature,
+            uint8_t swingV, uint8_t swingH,
+            bool turboMode, bool iFeelMode) {
+  GreeHeatpumpIR::generateCommand(buffer,
+      powerMode, operatingMode,
+      fanSpeed, temperature,
+      swingV, swingH,
+      turboMode, iFeelMode);
+
+  buffer[2] = turboMode ? 0x70 : 0x60;
+  buffer[3] = 0x50;
+  if (swingV == GREE_VDIR_SWING)
+    swingV = GREE_VDIR_AUTO;
+  buffer[4] = swingV;
+  buffer[5] |= 0x20;
+}
+
+void GreeYAAHeatpumpIR::generateCommand(uint8_t * buffer,
+            uint8_t powerMode, uint8_t operatingMode,
+            uint8_t fanSpeed, uint8_t temperature,
+            uint8_t swingV, uint8_t swingH,
+            bool turboMode, bool iFeelMode) {
+  GreeHeatpumpIR::generateCommand(buffer,
+      powerMode, operatingMode,
+      fanSpeed, temperature,
+      swingV, swingH,
+      turboMode, iFeelMode);
+
+  buffer[2] = GREE_LIGHT_BIT; // bits 0..3 always 0000, bits 4..7 TURBO,LIGHT,HEALTH,X-FAN
+  buffer[3] = 0x50; // bits 4..7 always 0101
+  buffer[5] |= 0x20;
+  buffer[6] = 0x20; // YAA1FB, FAA1FB1, YB1F2 bits 4..7 always 0010
+
+  if (turboMode)
+  {
+    buffer[2] |= GREE_TURBO_BIT;
+  }
+  if (swingV == GREE_VDIR_SWING)
+  {
+    buffer[0] |= GREE_VSWING; // Enable swing by setting bit 6
+  }
+  else if (swingV != GREE_VDIR_AUTO)
+  {
+    buffer[5] = swingV;
+  }
+}
+
+void GreeiFeelHeatpumpIR::generateCommand(uint8_t * buffer,
+            uint8_t powerMode, uint8_t operatingMode,
+            uint8_t fanSpeed, uint8_t temperature,
+            uint8_t swingV, uint8_t swingH,
+            bool turboMode, bool iFeelMode) {
+  GreeHeatpumpIR::generateCommand(buffer,
+      powerMode, operatingMode,
+      fanSpeed, temperature,
+      swingV, swingH,
+      turboMode, iFeelMode);
+
+  if (iFeelMode) {
+    buffer[5] |= GREE_IFEEL_BIT;
+  }
+}
+
+void GreeYACHeatpumpIR::generateCommand(uint8_t * buffer,
+            uint8_t powerMode, uint8_t operatingMode,
+            uint8_t fanSpeed, uint8_t temperature,
+            uint8_t swingV, uint8_t swingH,
+            bool turboMode, bool iFeelMode) {
+  GreeiFeelHeatpumpIR::generateCommand(buffer,
+      powerMode, operatingMode,
+      fanSpeed, temperature,
+      swingV, swingH,
+      turboMode, iFeelMode);
+
+  if (swingH == GREE_HDIR_AUTO)
+    swingH = GREE_HDIR_SWING;
+
+  buffer[4] |= (swingH << 4); // GREE_YT will ignore packets where this is set
+
+  buffer[2] = GREE_LIGHT_BIT; // bits 0..3 always 0000, bits 4..7 TURBO,LIGHT,HEALTH,X-FAN
+  buffer[3] = 0x50; // bits 4..7 always 0101
+  buffer[5] |= 0x20;
+  buffer[6] = 0x20; // YAA1FB, FAA1FB1, YB1F2 bits 4..7 always 0010
+
+  if (turboMode)
+  {
+    buffer[2] |= GREE_TURBO_BIT;
+  }
+  if (swingV == GREE_VDIR_SWING)
+  {
+    buffer[0] |= GREE_VSWING; // Enable swing by setting bit 6
+  }
+  else if (swingV != GREE_VDIR_AUTO)
+  {
+    buffer[5] = swingV;
+  }
+}
+
+void GreeYTHeatpumpIR::generateCommand(uint8_t * buffer,
+            uint8_t powerMode, uint8_t operatingMode,
+            uint8_t fanSpeed, uint8_t temperature,
+            uint8_t swingV, uint8_t swingH,
+            bool turboMode, bool iFeelMode) {
+  GreeiFeelHeatpumpIR::generateCommand(buffer,
+      powerMode, operatingMode,
+      fanSpeed, temperature,
+      swingV, swingH,
+      turboMode, iFeelMode);
+
+  buffer[2] = GREE_LIGHT_BIT | GREE_HEALTH_BIT; // HEALTH is always on for GREE_YT
+  buffer[3] = 0x50; // bits 4..7 always 0101
+
+  if (turboMode)
+  {
+    buffer[2] |= GREE_TURBO_BIT;
+  }
+  if (swingV == GREE_VDIR_SWING)
+  {
+    buffer[0] |= GREE_VSWING; // Enable swing by setting bit 6
+    buffer[4] = swingV;
+  }
+}
+
+void GreeHeatpumpIR::calculateChecksum(uint8_t * buffer) {
+  buffer[7] = (((
+   (buffer[0] & 0x0F) +
+   (buffer[1] & 0x0F) +
+   (buffer[2] & 0x0F) +
+   (buffer[3] & 0x0F) +
+   ((buffer[5] & 0xF0) >> 4) +
+   ((buffer[6] & 0xF0) >> 4) +
+   ((buffer[7] & 0xF0) >> 4) +
+    0x0A) & 0x0F) << 4) | (buffer[7] & 0x0F);
+}
+
+void GreeYANHeatpumpIR::calculateChecksum(uint8_t * buffer) {
+  buffer[7] = (
+    (buffer[0] << 4) +
+    (buffer[1] << 4) +
+    0xC0);
+}
+
 // Send the Gree code
 void GreeHeatpumpIR::sendGree(IRSender& IR, uint8_t powerMode, uint8_t operatingMode, uint8_t fanSpeed, uint8_t temperature, uint8_t swingV, uint8_t swingH, bool turboMode, bool iFeelMode)
 {
-  (void)swingH;
+  uint8_t GreeTemplate[8];
 
-  uint8_t GreeTemplate[] = { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 };
-  //                            0     1     2     3     4     5     6     7
+  generateCommand(
+      GreeTemplate,
+      powerMode, operatingMode,
+      fanSpeed, temperature,
+      swingV, swingH,
+      turboMode, iFeelMode);
 
-  uint8_t i;
-
-  if (greeModel != GREE_YT) {
-    GreeTemplate[5] = 0x20;
-  }
-
-  // Set the Fan speed, operating mode and power state
-  GreeTemplate[0] = fanSpeed | operatingMode | powerMode;
-  // Set the temperature
-  GreeTemplate[1] = temperature;
-
-  // Gree YAN-specific
-  if (greeModel == GREE_YAN)
-  {
-    GreeTemplate[2] = turboMode ? 0x70 : 0x60;
-    GreeTemplate[3] = 0x50;
-    GreeTemplate[4] = swingV;
-  }
-  if (greeModel == GREE_YAC)
-  {
-    GreeTemplate[4] |= (swingH << 4); // GREE_YT will ignore packets where this is set
-  }
-  if (greeModel == GREE_YAC || greeModel == GREE_YT)
-  {
-    if (iFeelMode)
-    {
-      GreeTemplate[5] |= GREE_IFEEL_BIT;
-    }
-  }
-  if (greeModel == GREE_YT) {
-    GreeTemplate[2] = GREE_LIGHT_BIT | GREE_HEALTH_BIT; // HEALTH is always on for GREE_YT
-    GreeTemplate[3] = 0x50; // bits 4..7 always 0101
-
-    if (turboMode)
-    {
-      GreeTemplate[2] |= GREE_TURBO_BIT;
-    }
-    if (swingV == GREE_VDIR_SWING)
-    {
-      GreeTemplate[0] |= GREE_VSWING; // Enable swing by setting bit 6
-      GreeTemplate[4] = swingV;
-    }
-  }
-  if (greeModel == GREE_YAA || greeModel == GREE_YAC)
-  {
-    GreeTemplate[2] = GREE_LIGHT_BIT; // bits 0..3 always 0000, bits 4..7 TURBO,LIGHT,HEALTH,X-FAN
-    GreeTemplate[3] = 0x50; // bits 4..7 always 0101
-    GreeTemplate[6] = 0x20; // YAA1FB, FAA1FB1, YB1F2 bits 4..7 always 0010
-
-    if (turboMode)
-    {
-      GreeTemplate[2] |= GREE_TURBO_BIT;
-    }
-    if (swingV == GREE_VDIR_SWING)
-    {
-      GreeTemplate[0] |= GREE_VSWING; // Enable swing by setting bit 6
-    }
-    else if (swingV != GREE_VDIR_AUTO)
-    {
-      GreeTemplate[5] = swingV;
-    }
-  }
-
-  // Calculate the checksum
-  if (greeModel == GREE_YAN)
-  {
-    GreeTemplate[7] = (
-      (GreeTemplate[0] << 4) +
-      (GreeTemplate[1] << 4) +
-      0xC0);
-  }
-  else
-  {
-    GreeTemplate[7] = (((
-     (GreeTemplate[0] & 0x0F) +
-     (GreeTemplate[1] & 0x0F) +
-     (GreeTemplate[2] & 0x0F) +
-     (GreeTemplate[3] & 0x0F) +
-     ((GreeTemplate[5] & 0xF0) >> 4) +
-     ((GreeTemplate[6] & 0xF0) >> 4) +
-     ((GreeTemplate[7] & 0xF0) >> 4) +
-      0x0A) & 0x0F) << 4) | (GreeTemplate[7] & 0x0F);
-  }
+  calculateChecksum(GreeTemplate);
 
   const auto & timings = getTimings();
 
@@ -319,7 +350,7 @@ void GreeHeatpumpIR::sendGree(IRSender& IR, uint8_t powerMode, uint8_t operating
   IR.space(timings.hdr_space);
 
   // Payload part #1
-  for (i=0; i<4; i++) {
+  for (int i=0; i<4; i++) {
     IR.sendIRbyte(GreeTemplate[i], timings.bit_mark, timings.zero_space, timings.one_space);
   }
   // Only three first bits of byte 4 are sent, this is always '010'
@@ -335,7 +366,7 @@ void GreeHeatpumpIR::sendGree(IRSender& IR, uint8_t powerMode, uint8_t operating
   IR.space(timings.msg_space);
 
   // Payload part #2
-  for (i=4; i<8; i++) {
+  for (int i=4; i<8; i++) {
     IR.sendIRbyte(GreeTemplate[i], timings.bit_mark, timings.zero_space, timings.one_space);
   }
 

--- a/GreeHeatpumpIR.h
+++ b/GreeHeatpumpIR.h
@@ -58,8 +58,6 @@
 #define GREE_HEALTH_BIT (1 << 6)
 #define GREE_XFAN_BIT   (1 << 7) // aka BLOW on some remotes
 
-
-
 // Gree model codes
 #define GREE_GENERIC 0
 #define GREE_YAN     1
@@ -100,15 +98,41 @@ class GreeHeatpumpIR : public HeatpumpIR
         return timings;
     };
 
-    uint8_t greeModel;
+    virtual void generateCommand(uint8_t * buffer,
+            uint8_t powerMode, uint8_t operatingMode,
+            uint8_t fanSpeed, uint8_t temperature,
+            uint8_t swingV, uint8_t swingH,
+            bool turboMode, bool iFeelMode);
+
+    virtual void calculateChecksum(uint8_t * buffer);
 
   public:
-    void send(IRSender& IR, uint8_t powerModeCmd, uint8_t operatingModeCmd, uint8_t fanSpeedCmd, uint8_t temperatureCmd, uint8_t swingVCmd, uint8_t swingHCmd);
-    void send(IRSender& IR, uint8_t powerModeCmd, uint8_t operatingModeCmd , uint8_t fanSpeedCmd , uint8_t temperatureCmd , uint8_t swingVCmd , uint8_t swingHCmd, bool turboMode);
-    void send(IRSender& IR, uint8_t powerModeCmd, uint8_t operatingModeCmd , uint8_t fanSpeedCmd , uint8_t temperatureCmd , uint8_t swingVCmd , uint8_t swingHCmd, bool turboMode, bool iFeelMode);
+    void send(
+            IRSender& IR,
+            uint8_t powerModeCmd, uint8_t operatingModeCmd,
+            uint8_t fanSpeedCmd, uint8_t temperatureCmd,
+            uint8_t swingVCmd, uint8_t swingHCmd) override {
+        send(
+            IR,
+            powerModeCmd, operatingModeCmd,
+            fanSpeedCmd, temperatureCmd,
+            swingVCmd, swingHCmd, false);
+    }
+
+    void send(
+            IRSender& IR,
+            uint8_t powerModeCmd, uint8_t operatingModeCmd,
+            uint8_t fanSpeedCmd, uint8_t temperatureCmd,
+            uint8_t swingVCmd, uint8_t swingHCmd,
+            bool turboMode, bool iFeelMode = false);
 
   private:
-    void sendGree(IRSender& IR, uint8_t powerMode, uint8_t operatingMode, uint8_t fanSpeed, uint8_t temperature, uint8_t swingV, uint8_t swingH, bool turboMode, bool iFeelMode);
+    void sendGree(
+            IRSender& IR,
+            uint8_t powerMode, uint8_t operatingMode,
+            uint8_t fanSpeed, uint8_t temperature,
+            uint8_t swingV, uint8_t swingH,
+            bool turboMode, bool iFeelMode);
 };
 
 class GreeGenericHeatpumpIR : public GreeHeatpumpIR
@@ -122,11 +146,14 @@ class GreeYANHeatpumpIR : public GreeHeatpumpIR
   public:
     GreeYANHeatpumpIR();
 
-  public:
-    void send(IRSender& IR, uint8_t powerModeCmd, uint8_t operatingModeCmd, uint8_t fanSpeedCmd, uint8_t temperatureCmd, uint8_t swingVCmd, uint8_t swingHCmd, bool turboMode)
-    {
-      GreeHeatpumpIR::send(IR, powerModeCmd, operatingModeCmd, fanSpeedCmd, temperatureCmd, swingVCmd, swingHCmd, turboMode);
-    }
+  protected:
+    virtual void generateCommand(uint8_t * buffer,
+            uint8_t powerMode, uint8_t operatingMode,
+            uint8_t fanSpeed, uint8_t temperature,
+            uint8_t swingV, uint8_t swingH,
+            bool turboMode, bool iFeelMode) override;
+
+    virtual void calculateChecksum(uint8_t * buffer) override;
 };
 
 class GreeYAAHeatpumpIR : public GreeHeatpumpIR
@@ -134,33 +161,52 @@ class GreeYAAHeatpumpIR : public GreeHeatpumpIR
   public:
     GreeYAAHeatpumpIR();
 
-  public:
-    void send(IRSender& IR, uint8_t powerModeCmd, uint8_t operatingModeCmd, uint8_t fanSpeedCmd, uint8_t temperatureCmd, uint8_t swingVCmd, uint8_t swingHCmd, bool turboMode)
-    {
-      GreeHeatpumpIR::send(IR, powerModeCmd, operatingModeCmd, fanSpeedCmd, temperatureCmd, swingVCmd, swingHCmd, turboMode);
-    }
+  protected:
+    virtual void generateCommand(uint8_t * buffer,
+            uint8_t powerMode, uint8_t operatingMode,
+            uint8_t fanSpeed, uint8_t temperature,
+            uint8_t swingV, uint8_t swingH,
+            bool turboMode, bool iFeelMode) override;
 };
 
 class GreeiFeelHeatpumpIR : public GreeHeatpumpIR
 {
   public:
-    void send(IRSender& IR, uint8_t powerModeCmd, uint8_t operatingModeCmd, uint8_t fanSpeedCmd, uint8_t temperatureCmd, uint8_t swingVCmd, uint8_t swingHCmd, bool turboMode, bool iFeelMode)
-    {
-      GreeHeatpumpIR::send(IR, powerModeCmd, operatingModeCmd, fanSpeedCmd, temperatureCmd, swingVCmd, swingHCmd, turboMode, iFeelMode);
-    }
-    void send(IRSender& IR, uint8_t currentTemperature);
+    using GreeHeatpumpIR::send;
+    void send(IRSender& IR, uint8_t currentTemperature) override;
+
+  protected:
+    virtual void generateCommand(uint8_t * buffer,
+            uint8_t powerMode, uint8_t operatingMode,
+            uint8_t fanSpeed, uint8_t temperature,
+            uint8_t swingV, uint8_t swingH,
+            bool turboMode, bool iFeelMode) override;
 };
 
 class GreeYACHeatpumpIR : public GreeiFeelHeatpumpIR
 {
   public:
     GreeYACHeatpumpIR();
+
+  protected:
+    virtual void generateCommand(uint8_t * buffer,
+            uint8_t powerMode, uint8_t operatingMode,
+            uint8_t fanSpeed, uint8_t temperature,
+            uint8_t swingV, uint8_t swingH,
+            bool turboMode, bool iFeelMode) override;
 };
 
 class GreeYTHeatpumpIR : public GreeiFeelHeatpumpIR
 {
   public:
     GreeYTHeatpumpIR();
+
+  protected:
+    virtual void generateCommand(uint8_t * buffer,
+            uint8_t powerMode, uint8_t operatingMode,
+            uint8_t fanSpeed, uint8_t temperature,
+            uint8_t swingV, uint8_t swingH,
+            bool turboMode, bool iFeelMode) override;
 };
 
 #endif

--- a/GreeHeatpumpIR.h
+++ b/GreeHeatpumpIR.h
@@ -6,19 +6,6 @@
 
 #include <HeatpumpIR.h>
 
-// Gree timing constants
-#define GREE_AIRCON1_HDR_MARK   9000
-#define GREE_AIRCON1_HDR_SPACE  4000
-#define GREE_AIRCON1_BIT_MARK   620
-#define GREE_AIRCON1_ONE_SPACE  1600
-#define GREE_AIRCON1_ZERO_SPACE 540
-#define GREE_AIRCON1_MSG_SPACE  19000
-
-// Timing specific for YAC features (I-Feel mode)
-#define GREE_YAC_HDR_MARK   6000
-#define GREE_YAC_HDR_SPACE  3000
-#define GREE_YAC_BIT_MARK   650
-
 // Power state
 #define GREE_AIRCON1_POWER_OFF  0x00
 #define GREE_AIRCON1_POWER_ON   0x08
@@ -84,7 +71,35 @@
 class GreeHeatpumpIR : public HeatpumpIR
 {
   protected:
+    struct Timings {
+        int hdr_mark;
+        int hdr_space;
+        int bit_mark;
+        int one_space;
+        int zero_space;
+        int msg_space;
+        int ifeel_hdr_mark;
+        int ifeel_hdr_space;
+        int ifeel_bit_mark;
+    };
+
     GreeHeatpumpIR();
+
+    virtual const Timings & getTimings() const {
+        static Timings timings = {
+            9000,
+            4000,
+            620,
+            1600,
+            540,
+            19000,
+            8200,
+            3800,
+            650,
+        };
+        return timings;
+    };
+
     uint8_t greeModel;
 
   public:

--- a/GreeHeatpumpIR.h
+++ b/GreeHeatpumpIR.h
@@ -83,20 +83,7 @@ class GreeHeatpumpIR : public HeatpumpIR
 
     GreeHeatpumpIR();
 
-    virtual const Timings & getTimings() const {
-        static Timings timings = {
-            9000,
-            4000,
-            620,
-            1600,
-            540,
-            19000,
-            8200,
-            3800,
-            650,
-        };
-        return timings;
-    };
+    virtual const Timings & getTimings() const;
 
     virtual void generateCommand(uint8_t * buffer,
             uint8_t powerMode, uint8_t operatingMode,
@@ -105,6 +92,18 @@ class GreeHeatpumpIR : public HeatpumpIR
             bool turboMode, bool iFeelMode);
 
     virtual void calculateChecksum(uint8_t * buffer);
+
+    virtual void sendGree(
+            IRSender& IR,
+            uint8_t powerMode, uint8_t operatingMode,
+            uint8_t fanSpeed, uint8_t temperature,
+            uint8_t swingV, uint8_t swingH,
+            bool turboMode, bool iFeelMode);
+
+    virtual void sendBuffer(
+            IRSender& IR,
+            const uint8_t * buffer,
+            size_t len = 8);
 
   public:
     void send(
@@ -119,20 +118,12 @@ class GreeHeatpumpIR : public HeatpumpIR
             swingVCmd, swingHCmd, false);
     }
 
-    void send(
+    virtual void send(
             IRSender& IR,
             uint8_t powerModeCmd, uint8_t operatingModeCmd,
             uint8_t fanSpeedCmd, uint8_t temperatureCmd,
             uint8_t swingVCmd, uint8_t swingHCmd,
             bool turboMode, bool iFeelMode = false);
-
-  private:
-    void sendGree(
-            IRSender& IR,
-            uint8_t powerMode, uint8_t operatingMode,
-            uint8_t fanSpeed, uint8_t temperature,
-            uint8_t swingV, uint8_t swingH,
-            bool turboMode, bool iFeelMode);
 };
 
 class GreeGenericHeatpumpIR : public GreeHeatpumpIR
@@ -207,6 +198,77 @@ class GreeYTHeatpumpIR : public GreeiFeelHeatpumpIR
             uint8_t fanSpeed, uint8_t temperature,
             uint8_t swingV, uint8_t swingH,
             bool turboMode, bool iFeelMode) override;
+};
+
+class GreeYAPHeatpumpIR : public GreeiFeelHeatpumpIR
+{
+  public:
+    GreeYAPHeatpumpIR();
+
+    using GreeiFeelHeatpumpIR::send;
+
+    virtual void send(
+            IRSender& IR,
+            uint8_t powerModeCmd, uint8_t operatingModeCmd,
+            uint8_t fanSpeedCmd, uint8_t temperatureCmd,
+            uint8_t swingVCmd, uint8_t swingHCmd,
+            bool turboMode, bool iFeelMode = false) override {
+        send(
+            IR,
+            powerModeCmd, operatingModeCmd,
+            fanSpeedCmd, temperatureCmd,
+            swingVCmd, swingHCmd,
+            turboMode, iFeelMode,
+            true);
+    }
+
+    virtual void send(
+            IRSender& IR,
+            uint8_t powerModeCmd, uint8_t operatingModeCmd,
+            uint8_t fanSpeedCmd, uint8_t temperatureCmd,
+            uint8_t swingVCmd, uint8_t swingHCmd,
+            bool turboMode, bool iFeelMode,
+            bool light, bool xfan = false,
+            bool health = false, bool valve = false,
+            bool sthtMode = false, bool enableWiFi = true);
+
+  protected:
+    virtual const Timings & getTimings() const override;
+
+    virtual void generateCommand(uint8_t * buffer,
+            uint8_t powerMode, uint8_t operatingMode,
+            uint8_t fanSpeed, uint8_t temperature,
+            uint8_t swingV, uint8_t swingH,
+            bool turboMode, bool iFeelMode) override;
+
+    void generateCommand(uint8_t * buffer,
+            uint8_t powerMode, uint8_t operatingMode,
+            uint8_t fanSpeed, uint8_t temperature,
+            uint8_t swingV, uint8_t swingH,
+            bool turboMode, bool iFeelMode,
+
+            bool light, bool xfan = false,
+            bool health = false, bool valve = false,
+            bool sthtMode = false, bool enableWiFi = true
+        );
+
+    virtual void sendGree(
+            IRSender& IR,
+            uint8_t powerMode, uint8_t operatingMode,
+            uint8_t fanSpeed, uint8_t temperature,
+            uint8_t swingV, uint8_t swingH,
+            bool turboMode, bool iFeelMode) override;
+
+    void sendGree(
+            IRSender& IR,
+            uint8_t powerMode, uint8_t operatingMode,
+            uint8_t fanSpeed, uint8_t temperature,
+            uint8_t swingV, uint8_t swingH,
+            bool turboMode, bool iFeelMode,
+
+            bool light, bool xfan = false,
+            bool health = false, bool valve = false,
+            bool sthtMode = false, bool enableWiFi = true);
 };
 
 #endif


### PR DESCRIPTION
This adds support for the YAP protocol (based on the Gree YAP1F7 remote) with extended features of the Gree Pular AC series.
    
The YAP protocol is similar to all other Gree protocols, but has many subtle differences, e.g. a longer message and different timings.  To implement it in an elegant way without much code duplication, some parts of the existing Gree IR code had to be significantly refactored.
    
This work is heavily based on the work of Thijs Houtenbos (@thoutenbos) included in this commit:  https://github.com/ToniA/arduino-heatpumpir/commit/4addf28e57526b4dbcdddc560c3002420e68cd6c
