### PR TITLE
IRSenderESP32: Fix LED pin switch between PWM and GPIO

### DIFF
--- a/IRSenderESP32.cpp
+++ b/IRSenderESP32.cpp
@@ -40,7 +40,12 @@ void IRSenderESP32::mark(int markLength)
   ledcWrite(_pwmChannel, 127);
 #endif  // ESP_ARDUINO_VERSION_MAJOR >= 3
   while((int)(micros() - beginning) < markLength);
+#if ( defined(ESP_ARDUINO_VERSION_MAJOR) && (ESP_ARDUINO_VERSION_MAJOR >= 3) )
+  ledcDetach(_pin);
+  pinMode(_pin, OUTPUT);
+#else   // ESP_ARDUINO_VERSION_MAJOR >= 3
   gpio_reset_pin(static_cast<gpio_num_t>(_pin));
+#endif  // ESP_ARDUINO_VERSION_MAJOR >= 3
   if (_inverted)
     digitalWrite(_pin, HIGH);
   else


### PR DESCRIPTION
In IRSenderESP32::mark we do setup PWM then send modulated carrier for specified time, then switch off back to GPIO mode. In old code switch off done using gpio_reset_pin() which doesn't work properly in Arduino-esp32 3+, as it wont detach it from ledc and return in GPIO mode (in Verbose mode it will complain about it).
What is worse, it doesn't turn off LED after sending IR codes, because digitalWrite doesnt work, so in boards where by design LED should have only short pulses it might lead to LED burnout (almost happened with me).

What does work, properly detaching from ledc and setting to GPIO output mode.

Additional node: i suggest to test for anybody else if it works, and on old arduino frameworks.
I verified this patch on my particular setup and it works very well.