### PR TITLE
Only install IRremoteESP8266 dependency on ESP platforms

### DIFF
--- a/library.json
+++ b/library.json
@@ -19,6 +19,7 @@
       "owner": "crankyoldgit",
       "name": "IRremoteESP8266",
       "version": "~2.8.4"
+      "platforms": ["espressif8266", "espressif32"]
     }
   ]
 }


### PR DESCRIPTION
Platforms like BK72XX and RP2040 don't need IRremoteESP8266 as dependency. Platformio will not try to bring in it on other platforms (including libretiny) because the it is explicitly disallowed:

https://github.com/crankyoldgit/IRremoteESP8266/blob/9785cb910d2b8c81785afb58d76090cb57c5b2df/library.json#L49

So this will only install it for ESP.

More info: https://github.com/esphome/esphome/pull/6955#issuecomment-2188338667

@rob-deutsch