### PR TITLE
Adding Panasonic EKE protocol

### DIFF
--- a/HeatpumpIRFactory.cpp
+++ b/HeatpumpIRFactory.cpp
@@ -69,6 +69,8 @@ HeatpumpIR* HeatpumpIRFactory::create(const char *modelName) {
     return new PanasonicCKPHeatpumpIR();
   } else if (strcmp_P(modelName, PSTR("panasonic_dke")) == 0) {
     return new PanasonicDKEHeatpumpIR();
+  } else if (strcmp_P(modelName, PSTR("panasonic_eke")) == 0) {
+    return new PanasonicEKEHeatpumpIR();
   } else if (strcmp_P(modelName, PSTR("panasonic_jke")) == 0) {
     return new PanasonicJKEHeatpumpIR();
   } else if (strcmp_P(modelName, PSTR("panasonic_lke")) == 0) {

--- a/PanasonicHeatpumpIR.cpp
+++ b/PanasonicHeatpumpIR.cpp
@@ -18,6 +18,17 @@ PanasonicDKEHeatpumpIR::PanasonicDKEHeatpumpIR() : PanasonicHeatpumpIR()
   _panasonicModel = PANASONIC_DKE;
 }
 
+PanasonicEKEHeatpumpIR::PanasonicEKEHeatpumpIR() : PanasonicHeatpumpIR()
+{
+  static const char model[] PROGMEM = "panasonic_eke";
+  static const char info[]  PROGMEM = "{\"mdl\":\"panasonic_eke\",\"dn\":\"Panasonic EKE\",\"mT\":16,\"xT\":30,\"fs\":6}";
+
+  _model = model;
+  _info = info;
+
+  _panasonicModel = PANASONIC_EKE;
+}
+
 PanasonicJKEHeatpumpIR::PanasonicJKEHeatpumpIR() : PanasonicHeatpumpIR()
 {
   static const char model[] PROGMEM = "panasonic_jke";
@@ -217,23 +228,29 @@ void PanasonicHeatpumpIR::sendPanasonic(IRSender& IR, uint8_t operatingMode, uin
   switch(_panasonicModel)
   {
     case PANASONIC_DKE:
+      panasonicTemplate[14] = temperature << 1;
       panasonicTemplate[17] = swingH; // Only the DKE model has a setting for the horizontal air flow
       panasonicTemplate[23] = 0x01;
       panasonicTemplate[25] = 0x06;
       break;
+    case PANASONIC_EKE:
+      panasonicTemplate[14] = IR.bitReverse(temperature << 1);
+      break;
     case PANASONIC_JKE:
+      panasonicTemplate[14] = temperature << 1;
       break;
     case PANASONIC_NKE:
+      panasonicTemplate[14] = temperature << 1;
       panasonicTemplate[17] = 0x06;
       break;
     case PANASONIC_LKE:
+      panasonicTemplate[14] = temperature << 1;
       panasonicTemplate[17] = 0x06;
       panasonicTemplate[13] = 0x02;
       break;
   }
 
   panasonicTemplate[13] |= operatingMode;
-  panasonicTemplate[14] = temperature << 1;
   panasonicTemplate[16] = fanSpeed | swingV;
   panasonicTemplate[21] = profile;
 

--- a/PanasonicHeatpumpIR.h
+++ b/PanasonicHeatpumpIR.h
@@ -1,5 +1,5 @@
 /*
-    Panasonic DKE/JKE/NKE heatpump control (DKE remote control P/N A75C2616 etc)
+    Panasonic DKE/EKE/JKE/NKE heatpump control (DKE remote control P/N A75C2616 etc)
 */
 #ifndef PanasonicHeatpumpIR_h
 #define PanasonicHeatpumpIR_h
@@ -7,7 +7,7 @@
 #include <HeatpumpIR.h>
 
 
-// Panasonic DKE, JKE & NKE timing constants (DKE remote control P/N A75C2616)
+// Panasonic DKE, EKE, JKE & NKE timing constants (DKE remote control P/N A75C2616)
 #define PANASONIC_AIRCON2_HDR_MARK   3500
 #define PANASONIC_AIRCON2_HDR_SPACE  1800
 #define PANASONIC_AIRCON2_BIT_MARK   420
@@ -15,7 +15,7 @@
 #define PANASONIC_AIRCON2_ZERO_SPACE 470
 #define PANASONIC_AIRCON2_MSG_SPACE  10000
 
-// Panasonic DKE, JNE & NKE codes
+// Panasonic DKE, EKE, JNE & NKE codes
 #define PANASONIC_AIRCON2_MODE_AUTO  0x00 // Operating mode
 #define PANASONIC_AIRCON2_MODE_HEAT  0x40
 #define PANASONIC_AIRCON2_MODE_COOL  0x30
@@ -50,13 +50,14 @@
 #define PANASONIC_JKE 1
 #define PANASONIC_NKE 2
 #define PANASONIC_LKE 3
+#define PANASONIC_EKE 4
 
 
 class PanasonicHeatpumpIR : public HeatpumpIR
 {
   protected: // Cannot create generic Panasonic heatpump instances
     PanasonicHeatpumpIR();
-    uint8_t _panasonicModel;  // Tells whether this is DKE, NKE or JKE (or other supported model...)
+    uint8_t _panasonicModel;  // Tells whether this is DKE, EKE, NKE or JKE (or other supported model...)
 
   public:
     void send(IRSender& IR, uint8_t powerModeCmd, uint8_t operatingModeCmd, uint8_t fanSpeedCmd, uint8_t temperatureCmd, uint8_t swingVCmd, uint8_t swingHCmd);
@@ -70,6 +71,12 @@ class PanasonicDKEHeatpumpIR : public PanasonicHeatpumpIR
 {
   public:
     PanasonicDKEHeatpumpIR();
+};
+
+class PanasonicEKEHeatpumpIR : public PanasonicHeatpumpIR
+{
+  public:
+    PanasonicEKEHeatpumpIR();
 };
 
 class PanasonicJKEHeatpumpIR : public PanasonicHeatpumpIR


### PR DESCRIPTION
This is a pull request to add a Panasonic EKE protocol.

This protocol is compatible with the following Panasonic units:
CS-E9PB4EA
CS-E12PB4EA
CU-E9PB4EA
CU-E12PB4EA
CS-ME9PB4EA
CS-ME12PB4EA
CS-ME18PB4EA
CS-ME21PB4EA

Using these remote controls:
A75C4347
A75C3208

Thanks to [ToniA](https://github.com/ToniA) and [germin8](https://github.com/germin8) who helped me:
[A75C3208 Remote](https://github.com/ToniA/arduino-heatpumpir/issues/185)