### PR TITLE
Don't automatically install IRremoteESP8266 on ESP32

### DIFF
--- a/IRSender.h
+++ b/IRSender.h
@@ -14,7 +14,7 @@
 #define LOGLN(...)
 #endif
 
-#if defined(ESP8266) || defined(ESP32)
+#if defined(ESP8266)
 #include <IRsend.h>  // From IRremoteESP8266 library
 #include <stdint.h>
 #endif

--- a/library.json
+++ b/library.json
@@ -19,7 +19,7 @@
       "owner": "crankyoldgit",
       "name": "IRremoteESP8266",
       "version": "~2.8.4",
-      "platforms": ["espressif8266", "espressif32"]
+      "platforms": ["espressif8266"]
     }
   ]
 }


### PR DESCRIPTION
IRremoteESP8266 does not support Arduino 3x and hence HeatpumpIR can't support Arduino 3x. IRremoteESP8266 has had an Arduino 3x PR open for a while but seems the maintainer is gone. ESPHome cant move to a new version of Arduino atm because of this. 

Remove the dependency on IRremoteESP8266 for ESP32. It can be manually included if someone wants it on Arduino 2x. 

