### PR TITLE
Update library.json for libretiny support

### DIFF
--- a/library.json
+++ b/library.json
@@ -12,7 +12,7 @@
     "url": "https://github.com/ToniA/arduino-heatpumpir.git"
   },
   "frameworks": "arduino",
-  "platforms": ["atmelavr", "espressif32", "espressif8266"],
+  "platforms": ["atmelavr", "espressif32", "espressif8266", "libretiny"],
   "version": "1.0.27",
   "dependencies": [
     {


### PR DESCRIPTION
ESPHome added strict mode for ldf, and due to libretiny missing from the library.json here, it would not compile the library in.