### PR TITLE
Add ESP-IDF framework support for ESP32

### DIFF
--- a/HeatpumpIR.h
+++ b/HeatpumpIR.h
@@ -7,7 +7,7 @@
 #ifndef HeatpumpIR_h
 #define HeatpumpIR_h
 
-#include <Arduino.h>
+#include "HeatpumpIRCompat.h"
 #include <IRSender.h>
 
 

--- a/HeatpumpIRCompat.h
+++ b/HeatpumpIRCompat.h
@@ -1,0 +1,109 @@
+/*
+    Compatibility header for Arduino and ESP-IDF
+    Provides unified interface for both frameworks
+*/
+#ifndef HeatpumpIRCompat_h
+#define HeatpumpIRCompat_h
+
+#ifdef ARDUINO
+// Arduino framework - use standard Arduino types and functions
+#include <Arduino.h>
+
+#elif defined(ESP_PLATFORM)
+// ESP-IDF framework (non-Arduino)
+#include <stdint.h>
+#include <stddef.h>
+#include <string.h>
+
+#include "freertos/FreeRTOS.h"
+#include "freertos/task.h"
+#include "driver/gpio.h"
+#include "esp_timer.h"
+#include "esp_rom_sys.h"
+#include "esp_log.h"
+
+// PROGMEM is a no-op on ESP32 (all memory is directly addressable)
+#ifndef PROGMEM
+#define PROGMEM
+#endif
+#ifndef pgm_read_byte
+#define pgm_read_byte(addr) (*(const uint8_t *)(addr))
+#endif
+#ifndef pgm_read_byte_near
+#define pgm_read_byte_near(addr) (*(const uint8_t *)(addr))
+#endif
+#ifndef memcpy_P
+#define memcpy_P(dst, src, n) memcpy(dst, src, n)
+#endif
+#ifndef PSTR
+#define PSTR(s) (s)
+#endif
+#ifndef strcmp_P
+#define strcmp_P(a, b) strcmp(a, b)
+#endif
+#ifndef sprintf_P
+#define sprintf_P sprintf
+#endif
+#ifndef F
+#define F(s) (s)
+#endif
+
+// Arduino type aliases
+typedef bool boolean;
+typedef uint8_t byte;
+
+// GPIO definitions
+#ifndef INPUT
+#define INPUT   GPIO_MODE_INPUT
+#endif
+#ifndef OUTPUT
+#define OUTPUT  GPIO_MODE_OUTPUT
+#endif
+#ifndef HIGH
+#define HIGH    1
+#endif
+#ifndef LOW
+#define LOW     0
+#endif
+
+// Timing functions
+inline void delayMicroseconds(uint32_t us) {
+  esp_rom_delay_us(us);
+}
+
+inline void delay(uint32_t ms) {
+  vTaskDelay(pdMS_TO_TICKS(ms));
+}
+
+inline unsigned long micros() {
+  return (unsigned long) esp_timer_get_time();
+}
+
+inline unsigned long millis() {
+  return (unsigned long) (esp_timer_get_time() / 1000);
+}
+
+// GPIO functions
+inline void pinMode(uint8_t pin, uint8_t mode) {
+  gpio_config_t io_conf = {};
+  io_conf.pin_bit_mask = (1ULL << pin);
+  io_conf.mode = (gpio_mode_t) mode;
+  io_conf.pull_up_en = GPIO_PULLUP_DISABLE;
+  io_conf.pull_down_en = GPIO_PULLDOWN_DISABLE;
+  io_conf.intr_type = GPIO_INTR_DISABLE;
+  gpio_config(&io_conf);
+}
+
+inline void digitalWrite(uint8_t pin, uint8_t val) {
+  gpio_set_level((gpio_num_t) pin, val);
+}
+
+inline int digitalRead(uint8_t pin) {
+  return gpio_get_level((gpio_num_t) pin);
+}
+
+#else
+#error "Unsupported platform - requires Arduino or ESP-IDF"
+#endif
+
+#endif // HeatpumpIRCompat_h

--- a/IRSender.cpp
+++ b/IRSender.cpp
@@ -1,4 +1,4 @@
-#include <Arduino.h>
+#include "HeatpumpIRCompat.h"
 #include <IRSender.h>
 
 // The generic functions of the abstract IRSender class

--- a/IRSender.h
+++ b/IRSender.h
@@ -4,11 +4,16 @@
 #ifndef IRSender_h
 #define IRSender_h
 
-#include <Arduino.h>
+#include "HeatpumpIRCompat.h"
 
 #if defined(DEBUG) && (DEBUG > 0)
+#ifdef ARDUINO
 #define LOG(...) Serial.print(__VA_ARGS__)
 #define LOGLN(...) Serial.println(__VA_ARGS__)
+#else
+#define LOG(...) ESP_LOGI("HeatpumpIR", __VA_ARGS__)
+#define LOGLN(...) ESP_LOGI("HeatpumpIR", __VA_ARGS__)
+#endif
 #else
 #define LOG(...)
 #define LOGLN(...)
@@ -70,7 +75,7 @@ class IRSenderBitBang : public IRSender
     int _halfPeriodicTime;
 };
 
-#ifdef ESP32
+#if defined(ESP32) && defined(ARDUINO)
 class IRSenderESP32 : public IRSender
 {
   public:

--- a/IRSenderBitBang.cpp
+++ b/IRSenderBitBang.cpp
@@ -1,4 +1,4 @@
-#include <Arduino.h>
+#include "HeatpumpIRCompat.h"
 #include <IRSender.h>
 
 // Send IR using the 'bit banging' on ESP8266 etc.

--- a/IRSenderBlaster.cpp
+++ b/IRSenderBlaster.cpp
@@ -1,4 +1,4 @@
-#include <Arduino.h>
+#include "HeatpumpIRCompat.h"
 #include <IRSender.h>
 
 // Send IR using the IR Blaster. The IR Blaster generates the 38 kHz carrier frequency

--- a/IRSenderESP32.cpp
+++ b/IRSenderESP32.cpp
@@ -1,10 +1,10 @@
-#include <Arduino.h>
+#include "HeatpumpIRCompat.h"
 
 // IRSender implementation for ESP32
-// Tested on R51M/E control with SENSEI air conditioner 
+// Tested on R51M/E control with SENSEI air conditioner
 // Maksym Krasovskyi
 
-#if defined ESP32
+#if defined(ESP32) && defined(ARDUINO)
 #include <IRSender.h>
 #if ( defined(ESP_ARDUINO_VERSION_MAJOR) && (ESP_ARDUINO_VERSION_MAJOR >= 3) )
 #include <driver/gpio.h>

--- a/IRSenderESP8266.cpp
+++ b/IRSenderESP8266.cpp
@@ -1,4 +1,5 @@
-#include <Arduino.h>
+#include "HeatpumpIRCompat.h"
+
 #ifdef ESP8266
 #include <IRSender.h>
 #include <core_esp8266_waveform.h>

--- a/IRSenderESP8266Alt.cpp
+++ b/IRSenderESP8266Alt.cpp
@@ -1,4 +1,5 @@
-#include <Arduino.h>
+#include "HeatpumpIRCompat.h"
+
 #ifdef ESP8266
 #include <IRSender.h>
 

--- a/IRSenderIRremoteESP8266.cpp
+++ b/IRSenderIRremoteESP8266.cpp
@@ -1,4 +1,5 @@
-#include <Arduino.h>
+#include "HeatpumpIRCompat.h"
+
 #if defined(ESP8266)
 #include <IRSender.h>
 

--- a/IRSenderPWM.cpp
+++ b/IRSenderPWM.cpp
@@ -1,10 +1,9 @@
-IRSenderPWM.cpp
-#include <Arduino.h>
+#include "HeatpumpIRCompat.h"
 #include <IRSender.h>
 
 // ESP8266 does not have the Arduino PWM control registers
 
-#if not defined ESP8266 && not defined ESP32 && not defined LIBRETINY
+#if not defined ESP8266 && not defined ESP32 && not defined ESP_PLATFORM && not defined LIBRETINY
 
 // Heavily based on Ken Shirriff's IRRemote library:
 // https://github.com/shirriff/Arduino-IRremote

--- a/OlimpiaStandardMaestroHeatpumpIR.cpp
+++ b/OlimpiaStandardMaestroHeatpumpIR.cpp
@@ -166,7 +166,7 @@ void OlimpiaStandardMaestroHeatpumpIR::sendMaestro(IRSender &IR, const HeatpumpS
   encodeMaestroState(state, command);
   
 
-  Serial.println(F("Starting to send IR"));
+  LOGLN(F("Starting to send IR"));
   // Set the frequency for the IR signal
   IR.setFrequency(38); // 38kHz frequency
 

--- a/library.json
+++ b/library.json
@@ -11,7 +11,7 @@
     "type": "git",
     "url": "https://github.com/ToniA/arduino-heatpumpir.git"
   },
-  "frameworks": "arduino",
+  "frameworks": ["arduino", "espidf"],
   "platforms": ["atmelavr", "espressif32", "espressif8266", "libretiny"],
   "version": "1.0.38",
   "dependencies": [


### PR DESCRIPTION
ESPHome is mostly uses IDF these days and one of the last Arduino only components that is heatpumpir. 

Add HeatpumpIRCompat.h compatibility header that provides Arduino-like functions (delay, millis, micros, pinMode, digitalWrite, etc.) when building with ESP-IDF framework.

Changes:
- Add HeatpumpIRCompat.h with platform detection for Arduino vs ESP-IDF
- Replace #include <Arduino.h> with #include "HeatpumpIRCompat.h" in all files
- Add espidf to supported frameworks in library.json

