### PR TITLE
Remove compiler warnings/errors

### DIFF
--- a/library.json
+++ b/library.json
@@ -21,5 +21,8 @@
       "version": "~2.8.4",
       "platforms": ["espressif8266"]
     }
-  ]
+  ],
+  "build": {
+    "flags": ["-Wno-error=overloaded-virtual"]
+  }
 }


### PR DESCRIPTION
Depending on compiler configurations or versions, some warnings or errors may appear. For example:

```
In file included from /home/test/tmp/esphome/tests/test_build_components/build/.esphome/packages/dc49d69c/tonia/HeatpumpIR/GreeHeatpumpIR.h:7,
                 from /home/test/tmp/esphome/tests/test_build_components/build/.esphome/packages/dc49d69c/tonia/HeatpumpIR/GreeHeatpumpIR.cpp:1:
/home/test/tmp/esphome/tests/test_build_components/build/.esphome/packages/dc49d69c/tonia/HeatpumpIR/HeatpumpIR.h:66:18: error: 'virtual void HeatpumpIR::send(IRSender&, uint8_t)' was hidden [-Werror=overloaded-virtual=]
   66 |     virtual void send(IRSender& IR, uint8_t currentTemperature);
      |                  ^~~~
/home/test/tmp/esphome/tests/test_build_components/build/.esphome/packages/dc49d69c/tonia/HeatpumpIR/GreeHeatpumpIR.h:121:18: note:   by 'GreeHeatpumpIR::send'
  121 |     virtual void send(
      |                  ^~~~
cc1plus: some warnings being treated as errors
```