### PR TITLE
Fix -Woverloaded-virtual at the source via using-declarations

### DIFF
--- a/AIRWAYHeatpumpIR.h
+++ b/AIRWAYHeatpumpIR.h
@@ -39,6 +39,7 @@
 class AIRWAYHeatpumpIR : public HeatpumpIR
 {
   public:
+    using HeatpumpIR::send;
     AIRWAYHeatpumpIR();
     void send(IRSender& IR, uint8_t powerModeCmd, uint8_t operatingModeCmd, uint8_t fanSpeedCmd, uint8_t temperatureCmd, uint8_t swingVCmd, uint8_t swingHCmd);
 

--- a/AUXHeatpumpIR.h
+++ b/AUXHeatpumpIR.h
@@ -35,6 +35,7 @@
 class AUXHeatpumpIR : public HeatpumpIR
 {
   public:
+    using HeatpumpIR::send;
     AUXHeatpumpIR();
     void send(IRSender& IR, uint8_t powerModeCmd, uint8_t operatingModeCmd, uint8_t fanSpeedCmd, uint8_t temperatureCmd, uint8_t swingVCmd, uint8_t swingHCmd);
 

--- a/BGHHeatpumpIR.h
+++ b/BGHHeatpumpIR.h
@@ -63,6 +63,7 @@
 class BGHHeatpumpIR : public HeatpumpIR
 {
   public:
+    using HeatpumpIR::send;
     BGHHeatpumpIR();
     void send(IRSender& IR, uint8_t powerModeCmd, uint8_t operatingModeCmd, uint8_t fanSpeedCmd, uint8_t temperatureCmd, uint8_t swingVCmd, uint8_t swingHCmd);
 

--- a/BalluHeatpumpIR.h
+++ b/BalluHeatpumpIR.h
@@ -34,6 +34,7 @@
 class BalluHeatpumpIR : public HeatpumpIR
 {
   public:
+    using HeatpumpIR::send;
     BalluHeatpumpIR();
     void send(IRSender& IR, uint8_t powerModeCmd, uint8_t operatingModeCmd, uint8_t fanSpeedCmd, uint8_t temperatureCmd, uint8_t swingVCmd, uint8_t swingHCmd);
 

--- a/CarrierHeatpumpIR.h
+++ b/CarrierHeatpumpIR.h
@@ -64,12 +64,14 @@ class CarrierHeatpumpIR : public HeatpumpIR
     uint8_t _carrierModel;
 
   public:
+    using HeatpumpIR::send;
     virtual void send(IRSender& IR, uint8_t powerModeCmd, uint8_t operatingModeCmd, uint8_t fanSpeedCmd, uint8_t temperatureCmd, uint8_t swingVCmd, uint8_t swingHCmd);
 };
 
 class CarrierNQVHeatpumpIR : public CarrierHeatpumpIR
 {
   public:
+    using CarrierHeatpumpIR::send;
     CarrierNQVHeatpumpIR();
 
   public:
@@ -82,6 +84,7 @@ class CarrierNQVHeatpumpIR : public CarrierHeatpumpIR
 class CarrierMCAHeatpumpIR : public CarrierHeatpumpIR
 {
   public:
+    using CarrierHeatpumpIR::send;
     CarrierMCAHeatpumpIR();
 
   public:

--- a/DaikinHeatpumpARC417IR.h
+++ b/DaikinHeatpumpARC417IR.h
@@ -34,6 +34,7 @@
 class DaikinHeatpumpARC417IR : public HeatpumpIR
 {
   public:
+    using HeatpumpIR::send;
     DaikinHeatpumpARC417IR();
     void send(IRSender& IR, uint8_t powerModeCmd, uint8_t operatingModeCmd, uint8_t fanSpeedCmd, uint8_t temperatureCmd, uint8_t swingVCmd, uint8_t swingHCmd);
 

--- a/DaikinHeatpumpARC480A14IR.h
+++ b/DaikinHeatpumpARC480A14IR.h
@@ -47,6 +47,7 @@
 class DaikinHeatpumpARC480A14IR : public HeatpumpIR
 {
   public:
+    using HeatpumpIR::send;
     DaikinHeatpumpARC480A14IR();
     void send(IRSender& IR, uint8_t powerModeCmd, uint8_t operatingModeCmd, uint8_t fanSpeedCmd, uint8_t temperatureCmd, uint8_t swingVCmd, uint8_t swingHCmd);
     void send(IRSender& IR, uint8_t powerModeCmd, uint8_t operatingModeCmd, uint8_t fanSpeedCmd, uint8_t temperatureCmd, uint8_t swingVCmd, uint8_t swingHCmd, uint8_t comfortMode, uint8_t econo, uint8_t sensor, uint8_t quiet, uint8_t powerful);

--- a/DaikinHeatpumpIR.h
+++ b/DaikinHeatpumpIR.h
@@ -34,6 +34,7 @@
 class DaikinHeatpumpIR : public HeatpumpIR
 {
   public:
+    using HeatpumpIR::send;
     DaikinHeatpumpIR();
     void send(IRSender& IR, uint8_t powerModeCmd, uint8_t operatingModeCmd, uint8_t fanSpeedCmd, uint8_t temperatureCmd, uint8_t swingVCmd, uint8_t swingHCmd);
 

--- a/ElectroluxHeatpumpIR.h
+++ b/ElectroluxHeatpumpIR.h
@@ -51,6 +51,7 @@ class ElectroluxHeatpumpIR : public HeatpumpIR
     uint8_t electroluxModel;
 
   public:
+    using HeatpumpIR::send;
     void send(IRSender& IR, uint8_t powerModeCmd, uint8_t operatingModeCmd, uint8_t fanSpeedCmd, uint8_t temperatureCmd, uint8_t swingVCmd, uint8_t swingHCmd);
 
   private:
@@ -61,6 +62,7 @@ class ElectroluxHeatpumpIR : public HeatpumpIR
 class ElectroluxYALHeatpumpIR : public ElectroluxHeatpumpIR
 {
   public:
+    using ElectroluxHeatpumpIR::send;
     ElectroluxYALHeatpumpIR();
 
   public:

--- a/FuegoHeatpumpIR.h
+++ b/FuegoHeatpumpIR.h
@@ -38,6 +38,7 @@
 class FuegoHeatpumpIR : public HeatpumpIR
 {
   public:
+    using HeatpumpIR::send;
     FuegoHeatpumpIR();
     void send(IRSender& IR, uint8_t powerModeCmd, uint8_t operatingModeCmd, uint8_t fanSpeedCmd, uint8_t temperatureCmd, uint8_t swingVCmd, uint8_t swingHCmd);
 

--- a/FujitsuHeatpumpIR.h
+++ b/FujitsuHeatpumpIR.h
@@ -38,6 +38,7 @@
 class FujitsuHeatpumpIR : public HeatpumpIR
 {
   public:
+    using HeatpumpIR::send;
     FujitsuHeatpumpIR();
     void send(IRSender& IR, uint8_t powerModeCmd, uint8_t operatingModeCmd, uint8_t fanSpeedCmd, uint8_t temperatureCmd, uint8_t swingVCmd, uint8_t swingHCmd);
     void send(IRSender& IR, uint8_t powerModeCmd, uint8_t operatingModeCmd, uint8_t fanSpeedCmd, uint8_t temperatureCmd, uint8_t swingVCmd, uint8_t swingHCmd, bool ecoModeCmd);

--- a/GreeHeatpumpIR.h
+++ b/GreeHeatpumpIR.h
@@ -106,6 +106,7 @@ class GreeHeatpumpIR : public HeatpumpIR
             size_t len = 8);
 
   public:
+    using HeatpumpIR::send;
     void send(
             IRSender& IR,
             uint8_t powerModeCmd, uint8_t operatingModeCmd,

--- a/HisenseHeatpumpIR.h
+++ b/HisenseHeatpumpIR.h
@@ -63,6 +63,7 @@
 class HisenseHeatpumpIR : public HeatpumpIR
 {
   public:
+    using HeatpumpIR::send;
     HisenseHeatpumpIR();
     void send(IRSender& IR, uint8_t powerModeCmd, uint8_t operatingModeCmd, uint8_t fanSpeedCmd, uint8_t temperatureCmd, uint8_t swingVCmd, uint8_t swingHCmd);
 

--- a/HitachiHeatpumpIR.h
+++ b/HitachiHeatpumpIR.h
@@ -38,6 +38,7 @@
 class HitachiHeatpumpIR : public HeatpumpIR
 {
   public:
+    using HeatpumpIR::send;
     HitachiHeatpumpIR();
     void send(IRSender& IR, uint8_t powerModeCmd, uint8_t operatingModeCmd, uint8_t fanSpeedCmd, uint8_t temperatureCmd, uint8_t swingVcmd, uint8_t swingHcmd);
 

--- a/HyundaiHeatpumpIR.h
+++ b/HyundaiHeatpumpIR.h
@@ -34,6 +34,7 @@
 class HyundaiHeatpumpIR : public HeatpumpIR
 {
   public:
+    using HeatpumpIR::send;
     HyundaiHeatpumpIR();
     void send(IRSender& IR, uint8_t powerModeCmd, uint8_t operatingModeCmd, uint8_t fanSpeedCmd, uint8_t temperatureCmd, uint8_t swingVCmd, uint8_t swingHCmd);
 

--- a/KY26HeatpumpIR.h
+++ b/KY26HeatpumpIR.h
@@ -63,6 +63,7 @@
 
 class KY26HeatpumpIR : public HeatpumpIR {
 public:
+    using HeatpumpIR::send;
   KY26HeatpumpIR();
   void send(IRSender &IR, uint8_t powerModeCmd, uint8_t operatingModeCmd,
             uint8_t fanSpeedCmd, uint8_t temperatureCmd, uint8_t swingVCmd,

--- a/KY26HeatpumpIR.h
+++ b/KY26HeatpumpIR.h
@@ -63,7 +63,7 @@
 
 class KY26HeatpumpIR : public HeatpumpIR {
 public:
-    using HeatpumpIR::send;
+  using HeatpumpIR::send;
   KY26HeatpumpIR();
   void send(IRSender &IR, uint8_t powerModeCmd, uint8_t operatingModeCmd,
             uint8_t fanSpeedCmd, uint8_t temperatureCmd, uint8_t swingVCmd,

--- a/MideaHeatpumpIR.h
+++ b/MideaHeatpumpIR.h
@@ -36,6 +36,7 @@
 class MideaHeatpumpIR : public HeatpumpIR
 {
   public:
+    using HeatpumpIR::send;
     MideaHeatpumpIR();
     void send(IRSender& IR, uint8_t powerModeCmd, uint8_t operatingModeCmd, uint8_t fanSpeedCmd, uint8_t temperatureCmd, uint8_t swingVCmd, uint8_t swingHCmd);
 

--- a/MitsubishiHeatpumpIR.h
+++ b/MitsubishiHeatpumpIR.h
@@ -87,6 +87,7 @@ class MitsubishiHeatpumpIR : public HeatpumpIR
     uint8_t _mitsubishiModel;  // Tells whether this is FD or EF (or other supported model...)
 
   public:
+    using HeatpumpIR::send;
     void send(IRSender& IR, uint8_t powerModeCmd, uint8_t operatingModeCmd, uint8_t fanSpeedCmd, uint8_t temperatureCmd, uint8_t swingVCmd, uint8_t swingHCmd);
 
   private:

--- a/MitsubishiHeavyFDTCHeatpumpIR.h
+++ b/MitsubishiHeavyFDTCHeatpumpIR.h
@@ -36,6 +36,7 @@
 class MitsubishiHeavyFDTCHeatpumpIR : public HeatpumpIR
 {
   public:
+    using HeatpumpIR::send;
     MitsubishiHeavyFDTCHeatpumpIR();
     void send(IRSender& IR, uint8_t powerModeCmd, uint8_t operatingModeCmd, uint8_t fanSpeedCmd, uint8_t temperatureCmd, uint8_t swingVCmd, uint8_t swingHCmd);
 

--- a/MitsubishiHeavyHeatpumpIR.h
+++ b/MitsubishiHeavyHeatpumpIR.h
@@ -154,6 +154,7 @@ class MitsubishiHeavyHeatpumpIR : public HeatpumpIR
     uint8_t _mitsubishiModel;  // Tells whether this is ZJ or ZM (or other supported model...)
 
   public:
+    using HeatpumpIR::send;
     void send(IRSender& IR, uint8_t powerModeCmd, uint8_t operatingModeCmd, uint8_t fanSpeedCmd, uint8_t temperatureCmd, uint8_t swingVCmd, uint8_t swingHCmd);
     virtual void send(IRSender& IR, uint8_t powerModeCmd, uint8_t operatingModeCmd, uint8_t fanSpeedCmd, uint8_t temperatureCmd, uint8_t swingVCmd, uint8_t swingHCmd, bool cleanModeCmd, bool silentModeCmd, bool _3DAutoCmd);
 };
@@ -161,6 +162,7 @@ class MitsubishiHeavyHeatpumpIR : public HeatpumpIR
 class MitsubishiHeavyZJHeatpumpIR : public MitsubishiHeavyHeatpumpIR
 {
   public:
+    using MitsubishiHeavyHeatpumpIR::send;
     MitsubishiHeavyZJHeatpumpIR();
     void send(IRSender& IR, uint8_t powerModeCmd, uint8_t operatingModeCmd, uint8_t fanSpeedCmd, uint8_t temperatureCmd, uint8_t swingVCmd, uint8_t swingHCmd, bool cleanModeCmd, bool silentModeCmd, bool _3DAutoCmd);
 
@@ -171,6 +173,7 @@ class MitsubishiHeavyZJHeatpumpIR : public MitsubishiHeavyHeatpumpIR
 class MitsubishiHeavyZMHeatpumpIR : public MitsubishiHeavyHeatpumpIR
 {
   public:
+    using MitsubishiHeavyHeatpumpIR::send;
     MitsubishiHeavyZMHeatpumpIR();
     void send(IRSender& IR, uint8_t powerModeCmd, uint8_t operatingModeCmd, uint8_t fanSpeedCmd, uint8_t temperatureCmd, uint8_t swingVCmd, uint8_t swingHCmd, bool cleanModeCmd, bool silentModeCmd, bool _3DAutoCmd);
 
@@ -181,6 +184,7 @@ class MitsubishiHeavyZMHeatpumpIR : public MitsubishiHeavyHeatpumpIR
 class MitsubishiHeavyZMPHeatpumpIR : public MitsubishiHeavyHeatpumpIR
 {
   public:
+    using MitsubishiHeavyHeatpumpIR::send;
     MitsubishiHeavyZMPHeatpumpIR();
     void send(IRSender& IR, uint8_t powerModeCmd, uint8_t operatingModeCmd, uint8_t fanSpeedCmd, uint8_t temperatureCmd, uint8_t swingVCmd, uint8_t swingHCmd, bool cleanModeCmd, bool silentModeCmd, bool _3DAutoCmd);
 
@@ -191,6 +195,7 @@ class MitsubishiHeavyZMPHeatpumpIR : public MitsubishiHeavyHeatpumpIR
 class MitsubishiHeavyZEAHeatpumpIR : public MitsubishiHeavyHeatpumpIR
 {
   public:
+    using MitsubishiHeavyHeatpumpIR::send;
     MitsubishiHeavyZEAHeatpumpIR();
     void send(IRSender& IR, uint8_t powerModeCmd, uint8_t operatingModeCmd, uint8_t fanSpeedCmd, uint8_t temperatureCmd, uint8_t swingVCmd, uint8_t swingHCmd, bool cleanModeCmd, bool silentModeCmd, bool _3DAutoCmd);
 

--- a/MitsubishiMSCHeatpumpIR.h
+++ b/MitsubishiMSCHeatpumpIR.h
@@ -39,6 +39,7 @@
 class MitsubishiMSCHeatpumpIR : public HeatpumpIR
 {
   public:
+    using HeatpumpIR::send;
     MitsubishiMSCHeatpumpIR();
     void send(IRSender& IR, uint8_t powerModeCmd, uint8_t operatingModeCmd, uint8_t fanSpeedCmd, uint8_t temperatureCmd, uint8_t swingVCmd, uint8_t swingHCmd);
 

--- a/MitsubishiSEZKDXXHeatpumpIR.h
+++ b/MitsubishiSEZKDXXHeatpumpIR.h
@@ -32,6 +32,7 @@
 class MitsubishiSEZKDXXHeatpumpIR : public HeatpumpIR
 {
   public:
+    using HeatpumpIR::send;
     MitsubishiSEZKDXXHeatpumpIR();
     void send(IRSender& IR, uint8_t powerModeCmd, uint8_t operatingModeCmd, uint8_t fanSpeedCmd, uint8_t temperatureCmd, uint8_t swingVCmd, uint8_t swingHCmd);
 

--- a/NibeHeatpumpIR.h
+++ b/NibeHeatpumpIR.h
@@ -67,7 +67,6 @@
 class NibeHeatpumpIR : public HeatpumpIR
 {
   public:
-    using HeatpumpIR::send;
     NibeHeatpumpIR();
     void send(IRSender& IR, uint8_t powerModeCmd, uint8_t operatingModeCmd, uint8_t fanSpeedCmd, uint8_t temperatureCmd, uint8_t swingVCmd, uint8_t swingHCmd);
     void send(IRSender& IR, uint8_t powerModeCmd, uint8_t operatingModeCmd, uint8_t fanSpeedCmd, uint8_t temperatureCmd, uint8_t swingVCmd, uint8_t swingHCmd, bool turboModeCmd, bool iFeelModeCmd);

--- a/NibeHeatpumpIR.h
+++ b/NibeHeatpumpIR.h
@@ -67,6 +67,7 @@
 class NibeHeatpumpIR : public HeatpumpIR
 {
   public:
+    using HeatpumpIR::send;
     NibeHeatpumpIR();
     void send(IRSender& IR, uint8_t powerModeCmd, uint8_t operatingModeCmd, uint8_t fanSpeedCmd, uint8_t temperatureCmd, uint8_t swingVCmd, uint8_t swingHCmd);
     void send(IRSender& IR, uint8_t powerModeCmd, uint8_t operatingModeCmd, uint8_t fanSpeedCmd, uint8_t temperatureCmd, uint8_t swingVCmd, uint8_t swingHCmd, bool turboModeCmd, bool iFeelModeCmd);

--- a/OlimpiaStandardMaestroHeatpumpIR.h
+++ b/OlimpiaStandardMaestroHeatpumpIR.h
@@ -20,7 +20,6 @@ struct HeatpumpState {
 
 class OlimpiaStandardMaestroHeatpumpIR : public HeatpumpIR {
 public:
-    using HeatpumpIR::send;
   OlimpiaStandardMaestroHeatpumpIR();
   void send(IRSender& IR, uint8_t powerModeCmd, uint8_t operatingModeCmd, uint8_t fanSpeedCmd, uint8_t temperatureCmd, uint8_t swingVCmd, uint8_t swingHCmd) override;
   void send(IRSender& IR, uint8_t currentTemperature) override;

--- a/OlimpiaStandardMaestroHeatpumpIR.h
+++ b/OlimpiaStandardMaestroHeatpumpIR.h
@@ -20,6 +20,7 @@ struct HeatpumpState {
 
 class OlimpiaStandardMaestroHeatpumpIR : public HeatpumpIR {
 public:
+    using HeatpumpIR::send;
   OlimpiaStandardMaestroHeatpumpIR();
   void send(IRSender& IR, uint8_t powerModeCmd, uint8_t operatingModeCmd, uint8_t fanSpeedCmd, uint8_t temperatureCmd, uint8_t swingVCmd, uint8_t swingHCmd) override;
   void send(IRSender& IR, uint8_t currentTemperature) override;

--- a/PanasonicAltDKEHeatpumpIR.h
+++ b/PanasonicAltDKEHeatpumpIR.h
@@ -54,6 +54,7 @@
 class PanasonicAltDKEHeatpumpIR : public HeatpumpIR
 {
   public:
+    using HeatpumpIR::send;
     PanasonicAltDKEHeatpumpIR();
     void send(IRSender& IR, uint8_t powerModeCmd, uint8_t operatingModeCmd, uint8_t fanSpeedCmd, uint8_t temperatureCmd, uint8_t swingVCmd, uint8_t swingHCmd);
     void send(IRSender& IR, uint8_t powerModeCmd, uint8_t operatingModeCmd, uint8_t fanSpeedCmd, uint8_t temperatureCmd, uint8_t swingVCmd, uint8_t swingHCmd, bool ionizerCmd);

--- a/PanasonicCKPHeatpumpIR.h
+++ b/PanasonicCKPHeatpumpIR.h
@@ -42,6 +42,7 @@
 class PanasonicCKPHeatpumpIR : public HeatpumpIR
 {
   public:
+    using HeatpumpIR::send;
     PanasonicCKPHeatpumpIR();
     void send(IRSender& IR, uint8_t powerModeCmd, uint8_t operatingModeCmd, uint8_t fanSpeedCmd, uint8_t temperatureCmd, uint8_t swingVCmd, uint8_t swingHCmd);
     void sendPanasonicCKPCancelTimer(IRSender& IR);

--- a/PanasonicHeatpumpIR.h
+++ b/PanasonicHeatpumpIR.h
@@ -60,6 +60,7 @@ class PanasonicHeatpumpIR : public HeatpumpIR
     uint8_t _panasonicModel;  // Tells whether this is DKE, EKE, NKE or JKE (or other supported model...)
 
   public:
+    using HeatpumpIR::send;
     void send(IRSender& IR, uint8_t powerModeCmd, uint8_t operatingModeCmd, uint8_t fanSpeedCmd, uint8_t temperatureCmd, uint8_t swingVCmd, uint8_t swingHCmd);
     void send(IRSender& IR, uint8_t powerModeCmd, uint8_t operatingModeCmd, uint8_t fanSpeedCmd, uint8_t temperatureCmd, uint8_t swingVCmd, uint8_t swingHCmd, bool powerfulCmd, bool quietCmd);
 

--- a/PhilcoPHS32HeatpumpIR.h
+++ b/PhilcoPHS32HeatpumpIR.h
@@ -38,6 +38,7 @@
 class PhilcoPHS32HeatpumpIR : public HeatpumpIR
 {
   public:
+    using HeatpumpIR::send;
     PhilcoPHS32HeatpumpIR();
     void send(IRSender& IR, uint8_t powerModeCmd, uint8_t operatingModeCmd, uint8_t fanSpeedCmd, uint8_t temperatureCmd, uint8_t swingVCmd, uint8_t swingHCmd);
 

--- a/R51MHeatpumpIR.h
+++ b/R51MHeatpumpIR.h
@@ -27,6 +27,7 @@
 class R51MHeatpumpIR : public HeatpumpIR
 {
   public:
+    using HeatpumpIR::send;
     R51MHeatpumpIR();
     void send(IRSender& IR, uint8_t powerModeCmd, uint8_t operatingModeCmd, uint8_t fanSpeedCmd, uint8_t temperatureCmd, uint8_t swingVCmd, uint8_t swingHCmd);
 };

--- a/SamsungHeatpumpIR.h
+++ b/SamsungHeatpumpIR.h
@@ -59,6 +59,7 @@ class SamsungHeatpumpIR : public HeatpumpIR
     uint8_t _samsungAQVModel;	
   
   public:
+    using HeatpumpIR::send;
     virtual void send(IRSender& IR, uint8_t powerModeCmd, uint8_t operatingModeCmd, uint8_t fanSpeedCmd, uint8_t temperatureCmd, uint8_t swingVCmd, uint8_t swingHCmd);
 
   private:
@@ -69,6 +70,7 @@ class SamsungHeatpumpIR : public HeatpumpIR
 class SamsungAQVHeatpumpIR : public SamsungHeatpumpIR
 {
   public:
+    using SamsungHeatpumpIR::send;
     SamsungAQVHeatpumpIR();
     void send(IRSender& IR, uint8_t powerModeCmd, uint8_t operatingModeCmd, uint8_t fanSpeedCmd, uint8_t temperatureCmd, uint8_t swingVCmd, uint8_t swingHCmd);
     
@@ -82,6 +84,7 @@ class SamsungAQVHeatpumpIR : public SamsungHeatpumpIR
 class SamsungFJMHeatpumpIR : public SamsungHeatpumpIR
 {
   public:
+    using SamsungHeatpumpIR::send;
     SamsungFJMHeatpumpIR();
     void send(IRSender& IR, uint8_t powerModeCmd, uint8_t operatingModeCmd, uint8_t fanSpeedCmd, uint8_t temperatureCmd, uint8_t swingVCmd, uint8_t swingHCmd);
     void send(IRSender& IR, uint8_t powerModeCmd, uint8_t operatingModeCmd, uint8_t fanSpeedCmd, uint8_t temperatureCmd, uint8_t swingVCmd, uint8_t swingHCmd, bool turboModeCmd);

--- a/SharpHeatpumpIR.h
+++ b/SharpHeatpumpIR.h
@@ -36,6 +36,7 @@
 class SharpHeatpumpIR : public HeatpumpIR
 {
   public:
+    using HeatpumpIR::send;
     SharpHeatpumpIR();
     void send(IRSender& IR, uint8_t powerModeCmd, uint8_t operatingModeCmd, uint8_t fanSpeedCmd, uint8_t temperatureCmd, uint8_t swingVCmd, uint8_t swingHCmd);
 

--- a/ToshibaDaiseikaiHeatpumpIR.h
+++ b/ToshibaDaiseikaiHeatpumpIR.h
@@ -38,6 +38,7 @@
 class ToshibaDaiseikaiHeatpumpIR : public CarrierHeatpumpIR
 {
   public:
+    using CarrierHeatpumpIR::send;
     ToshibaDaiseikaiHeatpumpIR();
 
   public:

--- a/ToshibaHeatpumpIR.h
+++ b/ToshibaHeatpumpIR.h
@@ -31,6 +31,7 @@
 class ToshibaHeatpumpIR : public HeatpumpIR
 {
   public:
+    using HeatpumpIR::send;
     ToshibaHeatpumpIR();
     void send(IRSender& IR, uint8_t powerModeCmd, uint8_t operatingModeCmd, uint8_t fanSpeedCmd, uint8_t temperatureCmd, uint8_t swingVCmd, uint8_t swingHCmd);
 

--- a/VaillantHeatpumpIR.h
+++ b/VaillantHeatpumpIR.h
@@ -45,6 +45,7 @@
 class VaillantHeatpumpIR : public HeatpumpIR
 {
   public:
+    using HeatpumpIR::send;
     VaillantHeatpumpIR();
     void send(IRSender& IR, uint8_t powerModeCmd, uint8_t operatingModeCmd, uint8_t fanSpeedCmd, uint8_t temperatureCmd, uint8_t swingVCmd, bool turboModeCmd, bool lightCmd);
     void send(IRSender& IR, uint8_t powerModeCmd, uint8_t operatingModeCmd, uint8_t fanSpeedCmd, uint8_t temperatureCmd, uint8_t swingVCmd, uint8_t swingHCmd);

--- a/ZHJG01HeatpumpIR.h
+++ b/ZHJG01HeatpumpIR.h
@@ -94,6 +94,7 @@
 class ZHJG01HeatpumpIR : public HeatpumpIR
 {
   public:
+    using HeatpumpIR::send;
     ZHJG01HeatpumpIR();
     void send(IRSender& IR, uint8_t powerModeCmd,
                             uint8_t operatingModeCmd,

--- a/ZHLT01HeatpumpIR.h
+++ b/ZHLT01HeatpumpIR.h
@@ -141,6 +141,7 @@
 class ZHLT01HeatpumpIR : public HeatpumpIR
 {
   public:
+    using HeatpumpIR::send;
     ZHLT01HeatpumpIR();
     void send(IRSender& IR, uint8_t powerModeCmd, 
 	                        uint8_t operatingModeCmd, 


### PR DESCRIPTION
Every subclass that overrides the 6-arg `send()` hides the base's 1-arg `send(IRSender&, uint8_t currentTemperature)` via C++ name hiding, triggering `-Woverloaded-virtual` (~35 warnings per ESP-IDF build).

The `-Wno-error=overloaded-virtual` flag added in b13e17f only stops the build from failing; the warnings still spam every log. This PR adds `using <Parent>::send;` to each derived class to unhide the base overload. No API change, warning gone at the source.

Verified with `g++ -Woverloaded-virtual -fsyntax-only` across all `*HeatpumpIR.h`: 35 warnings → 0. Also build-tested via ESPHome on ESP32-S3 / ESP-IDF.
