### PR TITLE
feat(zj): add HiPower, ECONO, and complete HDIR mappings

### DIFF
--- a/HeatpumpIR.h
+++ b/HeatpumpIR.h
@@ -52,6 +52,9 @@
 #define HDIR_MLEFT  4
 #define HDIR_MRIGHT 5
 #define HDIR_RIGHT  6
+#define HDIR_3DAUTO      7
+#define HDIR_LEFTRIGHT   8
+#define HDIR_RIGHTLEFT   9
 
 
 class HeatpumpIR

--- a/MitsubishiHeavyHeatpumpIR.cpp
+++ b/MitsubishiHeavyHeatpumpIR.cpp
@@ -119,6 +119,12 @@ void MitsubishiHeavyZJHeatpumpIR::send(IRSender& IR, uint8_t powerModeCmd, uint8
     case FAN_3:
       fanSpeed = MITSUBISHI_HEAVY_ZJ_FAN3;
       break;
+    case FAN_4: //Map FAN_4 to HiPower
+      fanSpeed = MITSUBISHI_HEAVY_ZJ_HIPOWER;
+      break;
+    case FAN_5: //Map FAN_5 to Econo
+      fanSpeed = MITSUBISHI_HEAVY_ZJ_ECONO;
+      break;
   }
 
   if (silentModeCmd)
@@ -179,6 +185,15 @@ void MitsubishiHeavyZJHeatpumpIR::send(IRSender& IR, uint8_t powerModeCmd, uint8
       break;
     case HDIR_MRIGHT:
       swingH = MITSUBISHI_HEAVY_ZJ_HS_MRIGHT;
+      break;
+    case HDIR_3DAUTO:
+      swingH = MITSUBISHI_HEAVY_ZJ_HS_3DAUTO;
+      break;
+    case HDIR_LEFTRIGHT:
+      swingH = MITSUBISHI_HEAVY_ZJ_HS_LEFTRIGHT;
+      break;
+    case HDIR_RIGHTLEFT:
+      swingH = MITSUBISHI_HEAVY_ZJ_HS_RIGHTLEFT;
       break;
   }
 


### PR DESCRIPTION
Wires up all pre-existing but unmapped constants in the Mitsubishi Heavy ZJ send() method.

## Changes
### Fan speeds
- FAN_4 -> HiPower (turbo fan, 0x40)
- FAN_5 -> ECONO (energy saver, 0x00)
### Horizontal swing
- HDIR_3DAUTO -> 3D Auto (0x04)
- HDIR_LEFTRIGHT -> Left-to-right sweep (0x84)
- HDIR_RIGHTLEFT -> Right-to-left sweep (0x44)

All constants were already defined in the header. This adds the switch-case wiring and aligns comments with the existing patterns in other Mitsubishi Heavy protocols:

- [ZMP](https://github.com/ToniA/arduino-heatpumpir/blob/master/MitsubishiHeavyHeatpumpIR.cpp#L536-L541): FAN_4 → HiPower, FAN_5 → Econo
- [ZM](https://github.com/ToniA/arduino-heatpumpir/blob/master/MitsubishiHeavyHeatpumpIR.cpp#L405-L410): FAN_4 → FAN4, FAN_5 → Econo
- [ZEA](https://github.com/ToniA/arduino-heatpumpir/blob/master/MitsubishiHeavyHeatpumpIR.cpp#L263): FAN_4 → FAN4 (FAN_5 not handled)